### PR TITLE
Optionally depend on server ydoc and docprovider

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,17 @@ for the frontend extension.
 ## Requirements
 
 - Jupyter Server
-- \[optional\] JupyterLab >= 4.0.0
+- \[optional\] JupyterLab >= 4.2.0
 
 ## Install
 
-To install the extension, execute:
+To install the extension for use in JupyterLab or Notebook 7, execute:
+
+```bash
+pip install jupyter_server_nbmodel[lab]
+```
+
+For API-only use:
 
 ```bash
 pip install jupyter_server_nbmodel

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Github Actions Status](https://github.com/datalayer/jupyter-server-nbmodel/workflows/Build/badge.svg)](https://github.com/datalayer/jupyter-server-nbmodel/actions/workflows/build.yml)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/datalayer/jupyter-server-nbmodel/main?urlpath=lab)
+
 A Jupyter Server extension to execute code cell from the server.
 
 This extension is composed of a Python package named `jupyter_server_nbmodel`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 
 [project.optional-dependencies]
-rtc = ["jupyterlab>=4.2.0", "jupyter_collaboration>=3.0.0a0"]
+lab = ["jupyterlab>=4.2.0", "jupyter-docprovider>=1.0.0b1", "jupyter-server-ydoc>=1.0.0b1"]
 test = ["pytest~=8.2", "pytest-cov", "pytest-jupyter[server]>=0.6", "pytest-timeout"]
 lint = ["mdformat>0.7", "mdformat-gfm>=0.3.5", "ruff>=0.4.0"]
 typing = ["mypy>=0.990"]


### PR DESCRIPTION
- Replace optional dependency on entire jupyter-collaboration package with only the packages which are needed
- Add the optional extras `[lab]` to the README
- Align require JupyterLab version in the README