### PR TITLE
Add execution start and end time metadata for code cells

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,9 @@
 import pytest
 
-pytest_plugins = ("pytest_jupyter.jupyter_server","jupyter_server_ydoc.pytest_plugin")
+pytest_plugins = (
+    "pytest_jupyter.jupyter_server",
+    "jupyter_server_ydoc.pytest_plugin"
+ )
 
 
 @pytest.fixture
@@ -19,7 +22,7 @@ def jp_server_config(jp_root_dir,jp_server_config):
                 "db_journal_mode": "OFF",
             },
             "YDocExtension": {"document_save_delay": 1},
-            'IdentityProvider': {'token': ''},
+            "IdentityProvider": {"token": ""},
             "disable_check_xsrf": True,
         },
     }

--- a/conftest.py
+++ b/conftest.py
@@ -1,12 +1,18 @@
 import pytest
 
-pytest_plugins = ("pytest_jupyter.jupyter_server",)
+pytest_plugins = ("pytest_jupyter.jupyter_server","jupyter_server_ydoc.pytest_plugin")
 
 
 @pytest.fixture
 def jp_server_config(jp_server_config):
     return {
         "ServerApp": {
-            "jpserver_extensions": {"jupyter_server_nbmodel": True, "jupyter_server_ydoc": False}
-        }
+            "jpserver_extensions": {
+                "jupyter_server_ydoc": True,
+                "jupyter_server_nbmodel": True,
+                "jupyter_server_fileid": True, 
+            },
+            'IdentityProvider': {'token': ''},
+            "disable_check_xsrf": True,
+        },
     }

--- a/conftest.py
+++ b/conftest.py
@@ -4,7 +4,7 @@ pytest_plugins = ("pytest_jupyter.jupyter_server","jupyter_server_ydoc.pytest_pl
 
 
 @pytest.fixture
-def jp_server_config(jp_server_config):
+def jp_server_config(jp_root_dir,jp_server_config):
     return {
         "ServerApp": {
             "jpserver_extensions": {
@@ -12,6 +12,13 @@ def jp_server_config(jp_server_config):
                 "jupyter_server_nbmodel": True,
                 "jupyter_server_fileid": True, 
             },
+            "SQLiteYStore": {"db_path": str(jp_root_dir.joinpath(".rtc_test.db"))},
+            "BaseFileIdManager": {
+                "root_dir": str(jp_root_dir),
+                "db_path": str(jp_root_dir.joinpath(".fid_test.db")),
+                "db_journal_mode": "OFF",
+            },
+            "YDocExtension": {"document_save_delay": 1},
             'IdentityProvider': {'token': ''},
             "disable_check_xsrf": True,
         },

--- a/conftest.py
+++ b/conftest.py
@@ -7,25 +7,27 @@ pytest_plugins = [
     "jupyter_server_ydoc.pytest_plugin"
 ]
 
+
 @pytest.fixture
-def jp_server_config(jp_root_dir,jp_server_config):
+def jp_server_config(jp_root_dir, jp_server_config):
     return {
         'ServerApp': {
             'jpserver_extensions': {
                 'jupyter_server_ydoc': True,
                 'jupyter_server_fileid': True,
-                'jupyter_server_nbmodel': True
+                'jupyter_server_nbmodel': True,
             },
             'token': '',
             'password': '',
-            'disable_check_xsrf': True},
-            "SQLiteYStore": {"db_path": str(jp_root_dir.joinpath(".rtc_test.db"))},
-            "BaseFileIdManager": {
-                "root_dir": str(jp_root_dir),
-                "db_path": str(jp_root_dir.joinpath(".fid_test.db")),
-                "db_journal_mode": "OFF",
-            },
-            'YDocExtension': {
-                'document_save_delay': 1
-            }
-    } 
+            'disable_check_xsrf': True
+        },
+        "SQLiteYStore": {"db_path": str(jp_root_dir.joinpath(".rtc_test.db"))},
+        "BaseFileIdManager": {
+            "root_dir": str(jp_root_dir),
+            "db_path": str(jp_root_dir.joinpath(".fid_test.db")),
+            "db_journal_mode": "OFF",
+        },
+        "YDocExtension": {
+            "document_save_delay": 1
+        }
+    }

--- a/conftest.py
+++ b/conftest.py
@@ -1,28 +1,31 @@
 import pytest
 
-pytest_plugins = (
+pytest_plugins = [
     "pytest_jupyter.jupyter_server",
+    "jupyter_server.pytest_plugin",
+    "jupyter_server_fileid.pytest_plugin",
     "jupyter_server_ydoc.pytest_plugin"
- )
-
+]
 
 @pytest.fixture
 def jp_server_config(jp_root_dir,jp_server_config):
     return {
-        "ServerApp": {
-            "jpserver_extensions": {
-                "jupyter_server_ydoc": True,
-                "jupyter_server_nbmodel": True,
-                "jupyter_server_fileid": True, 
+        'ServerApp': {
+            'jpserver_extensions': {
+                'jupyter_server_ydoc': True,
+                'jupyter_server_fileid': True,
+                'jupyter_server_nbmodel': True
             },
+            'token': '',
+            'password': '',
+            'disable_check_xsrf': True},
             "SQLiteYStore": {"db_path": str(jp_root_dir.joinpath(".rtc_test.db"))},
             "BaseFileIdManager": {
                 "root_dir": str(jp_root_dir),
                 "db_path": str(jp_root_dir.joinpath(".fid_test.db")),
                 "db_journal_mode": "OFF",
             },
-            "YDocExtension": {"document_save_delay": 1},
-            "IdentityProvider": {"token": ""},
-            "disable_check_xsrf": True,
-        },
-    }
+            'YDocExtension': {
+                'document_save_delay': 1
+            }
+    } 

--- a/jupyter_server_nbmodel/event_logger.py
+++ b/jupyter_server_nbmodel/event_logger.py
@@ -1,8 +1,8 @@
 from jupyter_events import EventLogger
 import pathlib
 
-JUPYTER_SERVER_EVENTS_URI = "https://events.jupyter.org/jupyter_server_nbmodel"
-DEFAULT_EVENTS_SCHEMA_PATH = pathlib.Path(__file__).parent / "event_schemas"
+_JUPYTER_SERVER_EVENTS_URI = "https://events.jupyter.org/jupyter_server_nbmodel"
+_DEFAULT_EVENTS_SCHEMA_PATH = pathlib.Path(__file__).parent / "event_schemas"
 
 class _EventLogger:
     _event_logger = None
@@ -16,8 +16,8 @@ class _EventLogger:
                 "https://events.jupyter.org/jupyter_server_nbmodel/cell_execution/v1",
             ]
             for schema_id in schema_ids:
-                rel_schema_path = schema_id.replace(JUPYTER_SERVER_EVENTS_URI + "/", "") + ".yaml"
-                schema_path = DEFAULT_EVENTS_SCHEMA_PATH / rel_schema_path
+                rel_schema_path = schema_id.replace(_JUPYTER_SERVER_EVENTS_URI + "/", "") + ".yaml"
+                schema_path = _DEFAULT_EVENTS_SCHEMA_PATH / rel_schema_path
                 cls._event_logger.register_event_schema(schema_path)
         return cls._event_logger
 

--- a/jupyter_server_nbmodel/event_logger.py
+++ b/jupyter_server_nbmodel/event_logger.py
@@ -1,0 +1,25 @@
+from jupyter_events import EventLogger
+import pathlib
+
+JUPYTER_SERVER_EVENTS_URI = "https://events.jupyter.org/jupyter_server_nbmodel"
+DEFAULT_EVENTS_SCHEMA_PATH = pathlib.Path(__file__).parent / "event_schemas"
+
+class _EventLogger:
+    _event_logger = None
+
+    @classmethod
+    def init_event_logger(cls) -> EventLogger:
+        """Initialize or return the existing Event Logger."""
+        if cls._event_logger is None:
+            cls._event_logger = EventLogger()
+            schema_ids = [
+                "https://events.jupyter.org/jupyter_server_nbmodel/cell_execution/v1",
+            ]
+            for schema_id in schema_ids:
+                rel_schema_path = schema_id.replace(JUPYTER_SERVER_EVENTS_URI + "/", "") + ".yaml"
+                schema_path = DEFAULT_EVENTS_SCHEMA_PATH / rel_schema_path
+                cls._event_logger.register_event_schema(schema_path)
+        return cls._event_logger
+
+
+event_logger = _EventLogger.init_event_logger()

--- a/jupyter_server_nbmodel/event_schemas/cell_execution/v1.yaml
+++ b/jupyter_server_nbmodel/event_schemas/cell_execution/v1.yaml
@@ -1,0 +1,42 @@
+"$id": https://events.jupyter.org/jupyter_server_nbmodel/cell_execution/v1
+version: "1"
+title: Cell Execution activities
+personal-data: true
+description: |
+  Record events of a cell execution.
+type: object
+required:
+  - event_type
+  - cell_id
+  - document_id
+  - timestamp
+properties:
+  event_type:
+    enum:
+      - execution_start
+      - execution_end
+
+  cell_id:
+    type: string
+    description: |
+      Cell id.
+
+  document_id:
+    type: string
+    description: |
+      Document id.
+
+  success:
+    type: boolean
+    description: |
+      Whether the cell execution was successful or not.
+
+  kernel_error:
+    type: string
+    description: |
+      Error message from the kernel.
+    
+  timestamp:
+    type: string
+    description: |
+      Timestamp of the event in ISO format.

--- a/jupyter_server_nbmodel/extension.py
+++ b/jupyter_server_nbmodel/extension.py
@@ -56,5 +56,4 @@ class Extension(ExtensionApp):
     async def stop_extension(self):
         if hasattr(self, "__execution_stack"):
             get_logger().info("Disposing the execution stack…")
-            await self.__execution_stack.dispose()
             await asyncio.wait_for(self.__execution_stack.dispose(), timeout=3)

--- a/jupyter_server_nbmodel/extension.py
+++ b/jupyter_server_nbmodel/extension.py
@@ -56,4 +56,5 @@ class Extension(ExtensionApp):
     async def stop_extension(self):
         if hasattr(self, "__execution_stack"):
             get_logger().info("Disposing the execution stack…")
+            await self.__execution_stack.dispose()
             await asyncio.wait_for(self.__execution_stack.dispose(), timeout=3)

--- a/jupyter_server_nbmodel/handlers.py
+++ b/jupyter_server_nbmodel/handlers.py
@@ -253,11 +253,12 @@ async def _execute_snippet(
             ycell["execution_count"] = reply_content.get("execution_count")
             ycell["execution_state"] = "idle"
             if metadata["record_timing"]:
-                time_info["shell.execute_reply"] = datetime.now(timezone.utc).isoformat()[:-6]
+                end_time = datetime.now(timezone.utc).isoformat()[:-6]
+                if reply_content["status"] == "ok":
+                    time_info["shell.execute_reply"] = end_time
+                else:
+                    time_info["execution_failed"] = end_time
                 ycell["metadata"]["execution"] = time_info
-    if reply_content["status"]!="ok":
-        time_info["execution_state"] = "failed"
-        ycell["metadata"]["execution"] = time_info
     return {
         "status": reply_content["status"],
         "execution_count": reply_content.get("execution_count"),

--- a/jupyter_server_nbmodel/handlers.py
+++ b/jupyter_server_nbmodel/handlers.py
@@ -243,6 +243,8 @@ async def _execute_snippet(
                 if metadata.get("record_timing", False):
                     time_info = ycell["metadata"].get("execution", {})
                     time_info["shell.execute_reply.started"] = execution_start_time
+                    # for compatibility with jupyterlab-execute-time also set:
+                    time_info["iopub.execute_input"] = execution_start_time
                     ycell["metadata"]["execution"] = time_info
             # Emit cell execution start event
             event_logger.emit(

--- a/jupyter_server_nbmodel/handlers.py
+++ b/jupyter_server_nbmodel/handlers.py
@@ -241,6 +241,16 @@ async def _execute_snippet(
                     time_info = ycell["metadata"].get("execution", {})
                     time_info["shell.execute_reply.started"] = datetime.now(timezone.utc).isoformat()[:-6]
                     ycell["metadata"]["execution"] = time_info
+            # Emit cell execution start event
+            event_logger.emit(
+                schema_id="https://events.jupyter.org/jupyter_server_nbmodel/cell_execution/v1",
+                data={
+                    "event_type": "execution_start",
+                    "cell_id": metadata["cell_id"],
+                    "document_id": metadata["document_id"],
+                    "timestamp": datetime.now(timezone.utc).isoformat()
+                }
+            )
     outputs = []
 
     # FIXME we don't check if the session is consistent (aka the kernel is linked to the document)

--- a/jupyter_server_nbmodel/handlers.py
+++ b/jupyter_server_nbmodel/handlers.py
@@ -228,11 +228,11 @@ async def _execute_snippet(
                 del ycell["outputs"][:]
                 ycell["execution_count"] = None
                 ycell["execution_state"] = "running"
-                if metadata["record_timing"]:
-                    time_info = ycell["metadata"].get("execution",{})
+                if metadata.get("record_timing", False):
+                    time_info = ycell["metadata"].get("execution", {})
                     time_info["shell.execute_reply.started"] = datetime.now(timezone.utc).isoformat()[:-6]
                     ycell["metadata"]["execution"] = time_info
-                
+
     outputs = []
 
     # FIXME we don't check if the session is consistent (aka the kernel is linked to the document)
@@ -252,7 +252,7 @@ async def _execute_snippet(
         with ycell.doc.transaction():
             ycell["execution_count"] = reply_content.get("execution_count")
             ycell["execution_state"] = "idle"
-            if metadata["record_timing"]:
+            if metadata and metadata.get("record_timing", False):
                 end_time = datetime.now(timezone.utc).isoformat()[:-6]
                 if reply_content["status"] == "ok":
                     time_info["shell.execute_reply"] = end_time

--- a/jupyter_server_nbmodel/handlers.py
+++ b/jupyter_server_nbmodel/handlers.py
@@ -238,6 +238,8 @@ async def _execute_snippet(
                 del ycell["outputs"][:]
                 ycell["execution_count"] = None
                 ycell["execution_state"] = "running"
+                if "execution" in ycell["metadata"]:
+                    del ycell["metadata"]["execution"]
                 if metadata.get("record_timing", False):
                     time_info = ycell["metadata"].get("execution", {})
                     time_info["shell.execute_reply.started"] = execution_start_time

--- a/jupyter_server_nbmodel/tests/test_handlers.py
+++ b/jupyter_server_nbmodel/tests/test_handlers.py
@@ -200,6 +200,8 @@ async def test_execution_timing_metadata(jp_fetch, pending_kernel_is_ready, rtc_
     assert reply_dt > started_dt, "The reply time is not greater than the started time."
     response2 = await jp_fetch("api", "kernels", kernel["id"], method="DELETE")
     assert response2.code == 204
+    await jp_serverapp.web_app.settings["jupyter_server_ydoc"].stop_extension()
+    del jp_serverapp.web_app.settings["file_id_manager"]
     await asyncio.sleep(1)
 
 @pytest.mark.timeout(TEST_TIMEOUT)

--- a/jupyter_server_nbmodel/tests/test_handlers.py
+++ b/jupyter_server_nbmodel/tests/test_handlers.py
@@ -2,6 +2,7 @@ import asyncio
 import datetime
 import json
 import re
+import nbformat
 
 import pytest
 from jupyter_client.kernelspec import NATIVE_KERNEL_NAME
@@ -148,6 +149,60 @@ async def test_post_erroneous_execute(jp_fetch, pending_kernel_is_ready, snippet
 
     await asyncio.sleep(1)
 
+@pytest.mark.timeout(TEST_TIMEOUT)
+async def test_execution_timing_metadata(jp_fetch, pending_kernel_is_ready, rtc_create_notebook, jp_serverapp):
+    snippet = "a = 1"
+    nb = nbformat.v4.new_notebook(
+        cells=[nbformat.v4.new_code_cell(source=snippet, execution_count=1)]
+    )
+    nb_content = nbformat.writes(nb, version=4)
+    path, _ = await rtc_create_notebook("test.ipynb", nb_content, store=True)
+    collaboration = jp_serverapp.web_app.settings["jupyter_server_ydoc"]
+    fim = jp_serverapp.web_app.settings["file_id_manager"]
+    document = await collaboration.get_document(
+        path=path, content_type="notebook", file_format="json", copy=False
+    )
+    doc = document.get()
+    document_id = f'json:notebook:{fim.get_id("test.ipynb")}'
+    cell_id = doc["cells"][0].get("id")
+
+    r = await jp_fetch(
+        "api", "kernels", method="POST", body=json.dumps({"name": NATIVE_KERNEL_NAME})
+    )
+    kernel = json.loads(r.body.decode())
+    await pending_kernel_is_ready(kernel["id"])
+
+    response = await wait_for_request(
+        jp_fetch,
+        "api",
+        "kernels",
+        kernel["id"],
+        "execute",
+        method="POST",
+        body=json.dumps({"code": snippet, "metadata":{"cell_id":cell_id,"document_id":document_id,"record_timing":True}}),
+    )
+    assert response.code == 200
+    cell_data = document.get()["cells"][0]
+    assert 'execution' in cell_data['metadata'], "'execution' does not exist in 'metadata'"
+
+    # Assert that start and end time exist in 'execution'
+    execution = cell_data['metadata']['execution']
+    assert 'shell.execute_reply.started' in execution, "'shell.execute_reply.started' does not exist in 'execution'"
+    assert 'shell.execute_reply' in execution, "'shell.execute_reply' does not exist in 'execution'"
+
+    started_time = execution['shell.execute_reply.started']
+    reply_time = execution['shell.execute_reply']
+
+    started_dt = datetime.datetime.fromisoformat(started_time)
+    reply_dt = datetime.datetime.fromisoformat(reply_time)
+
+    # Assert that reply_time is greater than started_time
+    assert reply_dt > started_dt, "The reply time is not greater than the started time."
+    response2 = await jp_fetch("api", "kernels", kernel["id"], method="DELETE")
+    assert response2.code == 204
+    await jp_serverapp.web_app.settings["jupyter_server_ydoc"].stop_extension()
+    del jp_serverapp.web_app.settings["file_id_manager"]
+    await asyncio.sleep(1)
 
 @pytest.mark.timeout(TEST_TIMEOUT)
 async def test_post_input_execute(jp_fetch, pending_kernel_is_ready):

--- a/jupyter_server_nbmodel/tests/test_handlers.py
+++ b/jupyter_server_nbmodel/tests/test_handlers.py
@@ -200,8 +200,6 @@ async def test_execution_timing_metadata(jp_fetch, pending_kernel_is_ready, rtc_
     assert reply_dt > started_dt, "The reply time is not greater than the started time."
     response2 = await jp_fetch("api", "kernels", kernel["id"], method="DELETE")
     assert response2.code == 204
-    await jp_serverapp.web_app.settings["jupyter_server_ydoc"].stop_extension()
-    del jp_serverapp.web_app.settings["file_id_manager"]
     await asyncio.sleep(1)
 
 @pytest.mark.timeout(TEST_TIMEOUT)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dynamic = ["version", "description", "authors", "urls", "keywords"]
 
 [project.optional-dependencies]
 lab = ["jupyterlab>=4.2.0", "jupyter-docprovider>=1.0.0b1", "jupyter-server-ydoc>=1.0.0b1"]
-test = ["pytest~=8.2", "pytest-cov", "pytest-jupyter[server]>=0.6", "pytest-timeout"]
+test = ["pytest~=8.2", "pytest-cov", "pytest-jupyter[server]>=0.6", "pytest-timeout", "jupyter-server-ydoc>=1.0.0b1"]
 lint = ["mdformat>0.7", "mdformat-gfm>=0.3.5", "ruff>=0.4.0"]
 typing = ["mypy>=0.990"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dynamic = ["version", "description", "authors", "urls", "keywords"]
 
 [project.optional-dependencies]
 lab = ["jupyterlab>=4.2.0", "jupyter-docprovider>=1.0.0b1", "jupyter-server-ydoc>=1.0.0b1"]
-test = ["pytest~=8.2", "pytest-cov", "pytest-jupyter[server]>=0.6", "pytest-timeout", "jupyter-server-ydoc>=1.0.0b1"]
+test = ["pytest~=8.2", "pytest-cov", "pytest-jupyter[server]>=0.6", "pytest-timeout", "jupyter-server-ydoc[test]>=1.0.0b1"]
 lint = ["mdformat>0.7", "mdformat-gfm>=0.3.5", "ruff>=0.4.0"]
 typing = ["mypy>=0.990"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,14 @@ dynamic = ["version", "description", "authors", "urls", "keywords"]
 
 [project.optional-dependencies]
 lab = ["jupyterlab>=4.2.0", "jupyter-docprovider>=1.0.0b1", "jupyter-server-ydoc>=1.0.0b1"]
-test = ["pytest~=8.2", "pytest-cov", "pytest-jupyter[server]>=0.6", "pytest-timeout", "jupyter-server-ydoc[test]>=1.0.0b1"]
+test = [
+  "pytest~=8.2",
+  "pytest-cov",
+  "pytest-jupyter[server]>=0.6",
+  "pytest-timeout",
+  "jupyter-server-ydoc[test]>=1.0.0b1",
+  "jupyter-server-fileid"
+]
 lint = ["mdformat>0.7", "mdformat-gfm>=0.3.5", "ruff>=0.4.0"]
 typing = ["mypy>=0.990"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,10 +81,14 @@ build_dir = "jupyter_server_nbmodel/labextension"
 [tool.pytest.ini_options]
 filterwarnings = [
   "error",
+  "ignore:Unclosed context <zmq.asyncio.Context:ResourceWarning",
+  "ignore:Unclosed socket <zmq.asyncio.Socket:ResourceWarning",
   "ignore:There is no current event loop:DeprecationWarning",
   "module:make_current is deprecated:DeprecationWarning",
   "module:clear_current is deprecated:DeprecationWarning",
   "module:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning",
+  # From anyio https://github.com/agronholm/anyio/pull/715
+  "ignore:Unclosed <MemoryObjectSendStream:ResourceWarning",
 ]
 
 [tool.mypy]

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -108,13 +108,17 @@ export class NotebookCellServerExecutor implements INotebookCellExecutor {
           const code = cell.model.sharedModel.getSource();
           const cellId = cell.model.sharedModel.getId();
           const documentId = notebook.sharedModel.getState('document_id');
-          const { recordTiming } = notebookConfig
+          const { recordTiming } = notebookConfig;
 
           const init = {
             method: 'POST',
             body: JSON.stringify({
               code,
-              metadata: { cell_id: cellId, document_id: documentId, record_timing: recordTiming }
+              metadata: {
+                cell_id: cellId,
+                document_id: documentId,
+                record_timing: recordTiming
+              }
             })
           };
           onCellExecutionScheduled({ cell });

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -108,12 +108,13 @@ export class NotebookCellServerExecutor implements INotebookCellExecutor {
           const code = cell.model.sharedModel.getSource();
           const cellId = cell.model.sharedModel.getId();
           const documentId = notebook.sharedModel.getState('document_id');
+          const { recordTiming } = notebookConfig
 
           const init = {
             method: 'POST',
             body: JSON.stringify({
               code,
-              metadata: { cell_id: cellId, document_id: documentId }
+              metadata: { cell_id: cellId, document_id: documentId, record_timing: recordTiming }
             })
           };
           onCellExecutionScheduled({ cell });


### PR DESCRIPTION
## References #22 

- Added execution start and end times to code cell metadata, visible when timing recording is enabled by user.
- Computed on the server side to ensure persistence even after the notebook is closed.

### Screenshots
![image](https://github.com/user-attachments/assets/a6bd4f11-b996-48a0-8b7e-bd364497fd4a)


