### PR TITLE
Remove outdated references to [rtc] in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,6 @@ For API-only use:
 pip install jupyter_server_nbmodel
 ```
 
-Or with recommendations:
-
-```bash
-pip install jupyter_server_nbmodel[rtc]
-```
-
 ## Uninstall
 
 To remove the extension, execute:


### PR DESCRIPTION
https://github.com/datalayer/jupyter-server-nbmodel/pull/21 replaces the `[rtc]` optional dependency group with `[lab]`, but the README still contains references to `[rtc]`. This PR updates the documentation to remove the outdated references to `[rtc]`.
