### PR TITLE
Diagram fix: Kernel doesn't update Y doc, Server does

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Execution of a Python code snippet: `print("hello")`
 ```mermaid
 sequenceDiagram
     actor Frontend; participant Shared Document; actor Server; participant ExecutionStack; actor Kernel
+    Frontend->>Shared Document: [*] busy
     Frontend->>+Server: POST /api/kernels/<id>/execute
     Server->>+ExecutionStack: put() request into queue
     ExecutionStack->>Kernel: Execute request msg
@@ -92,12 +93,15 @@ sequenceDiagram
         ExecutionStack-->>Server: null
         Server-->>-Frontend: Request status 202
     end
-    Kernel-->>ExecutionStack: Execution reply
+    Kernel-->>Server: Execution reply
+    Server->>Shared Document: [𝒏] idle
+    Server-->>ExecutionStack: execution_count, status, outputs
+    Shared Document->>Frontend: [𝒏] idle
     deactivate Kernel
     Frontend->>+Server: GET /api/kernels/<id>/requests/<uid>
     Server->>ExecutionStack: get() task result
-    ExecutionStack-->>Server: Result
-    Server-->>-Frontend: Status 200 & result
+    ExecutionStack-->>Server: execution_count, status, outputs
+    Server-->>-Frontend: Status 200 & { execution_count, status, outputs }
 ```
 
 ### With input case
@@ -107,6 +111,7 @@ Execution of a Python code snippet: `input("Age:")`
 ```mermaid
 sequenceDiagram
     actor Frontend; participant Shared Document; actor Server; participant ExecutionStack; actor Kernel
+    Frontend->>Shared Document: [*] busy
     Frontend->>+Server: POST /api/kernels/<id>/execute
     Server->>+ExecutionStack: put() request into queue
     ExecutionStack->>Kernel: Execute request msg
@@ -138,12 +143,15 @@ sequenceDiagram
         ExecutionStack-->>Server: null
         Server-->>-Frontend: Request status 202
     end
-    Kernel-->>ExecutionStack: Execution reply
+    Kernel-->>Server: Execution reply
+    Server->>Shared Document: [𝒏] idle
+    Server-->>ExecutionStack: execution_count, status, outputs
+    Shared Document->>Frontend: [𝒏] idle
     deactivate Kernel
     Frontend->>+Server: GET /api/kernels/<id>/requests/<uid>
     Server->>ExecutionStack: get() task result
-    ExecutionStack-->>Server: Result
-    Server-->>-Frontend: Status 200 & result
+    ExecutionStack-->>Server: execution_count, status, outputs
+    Server-->>-Frontend: Status 200 & { execution_count, status, outputs }
 ```
 
 > \[!NOTE\]


### PR DESCRIPTION
Based on my understanding of code, please check

[Before](https://github.com/datalayer/jupyter-server-nbmodel?tab=readme-ov-file#how-does-it-works) | [After](https://github.com/cben/jupyter-server-nbmodel/tree/diagram?tab=readme-ov-file#how-does-it-works)

- [x] Kernel doesn't touch Y doc, it's the Server that updates it
- [x] also moved Shared document left between Frontend and Server
- [x] using `actor` stick figure shapes for actual separate processes
  - "Shared Document" is abstraction, actually exists as separate Y models inside Frontend(s) and inside Server.  But I think it's fine for this diagram.
  - ExecutionStack is an object inside Server.  Mermaid can [group participants](https://mermaid.js.org/syntax/sequenceDiagram#grouping-box) but that might look too messy?  
    - [x] WDYT re-wording to e.g. "put() request into queue", "get() task result" to imply these are local function calls, not network messages?
- [x] After execute_reply, I wasn't sure if diagram should elaborate on Server updating the Y model with 'idle' state & count?  It [does](https://github.com/datalayer/jupyter-server-nbmodel/blob/8bf649c71a88508d9cca1dc9ad5befc60ff0ba2f/jupyter_server_nbmodel/actions.py#L224-L232), but it _also_ returns them over HTTP as already shown in diagram; not sure which drives notebook changing `[*]` -> `[15]`...
