### PR TITLE
Propagate Error to API

### DIFF
--- a/jupyter_server_nbmodel/actions.py
+++ b/jupyter_server_nbmodel/actions.py
@@ -275,6 +275,7 @@ async def kernel_worker(
             queue.task_done()
             get_logger().debug(f"Execution request {uid} processed for kernel {kernel_id}.")
         except (asyncio.CancelledError, KeyboardInterrupt, RuntimeError) as e:
+            results[uid] = {"error": str(e)}
             get_logger().debug(
                 f"Stopping execution requests worker for kernel {kernel_id}…", exc_info=e
             )


### PR DESCRIPTION
## Fixes #27 

### Description

Now the error is correctly propagated to the API with a **500** status code in case of **runtime errors in the kernel worker**.

However, the frontend **still does not react** to this 500 status when it's received.

We may need to **handle this on the frontend side**  too.
