### PR TITLE
Fix crash when handling a stream after non-stream output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         jlpm
         jlpm run lint:check
 
-    - name: Test the extension
+    - name: Frontend test
       run: |
         set -eux
         jlpm run test
@@ -41,14 +41,18 @@ jobs:
       run: |
         set -eux
         python -m pip install .[test]
-
-        pytest -vv -r ap --forked --cov jupyter_server_nbmodel
         jupyter server extension list
         jupyter server extension list 2>&1 | grep -ie "jupyter_server_nbmodel.*OK"
 
         jupyter labextension list
         jupyter labextension list 2>&1 | grep -ie "jupyter-server-nbmodel.*OK"
+
         python -m jupyterlab.browser_check
+
+    - name: Python test
+      run: |
+        set -eux
+        pytest
 
     - name: Package the extension
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         set -eux
         python -m pip install .[test]
 
-        pytest -vv -r ap --cov jupyter_server_nbmodel
+        pytest -vv -r ap --forked --cov jupyter_server_nbmodel
         jupyter server extension list
         jupyter server extension list 2>&1 | grep -ie "jupyter_server_nbmodel.*OK"
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ jupyter labextension develop . --overwrite
 To execute them, run:
 
 ```sh
-pytest -vv -r ap --cov jupyter_server_nbmodel
+pytest
 ```
 
 #### Frontend tests

--- a/jupyter_server_nbmodel/actions.py
+++ b/jupyter_server_nbmodel/actions.py
@@ -107,7 +107,7 @@ def _output_hook(outputs: list[NotebookNode], ycell: y.Map | None, msg: dict) ->
                     # FIXME Logic is quite complex at https://github.com/jupyterlab/jupyterlab/blob/7ae2d436fc410b0cff51042a3350ba71f54f4445/packages/outputarea/src/model.ts#L518
                     if text.endswith((os.linesep, "\n")):
                         text = text[:-1]
-                    if (not cell_outputs) or (cell_outputs[-1]["name"] != output["name"]):
+                    if (not cell_outputs) or (cell_outputs[-1].get("name", None) != output["name"]):
                         output["text"] = [text]
                         cell_outputs.append(output)
                     else:

--- a/jupyter_server_nbmodel/tests/test_handlers.py
+++ b/jupyter_server_nbmodel/tests/test_handlers.py
@@ -74,7 +74,7 @@ def pending_kernel_is_ready(jp_serverapp):
     return _
 
 
-@pytest.mark.timeout(TEST_TIMEOUT)
+@pytest.mark.timeout(2 * TEST_TIMEOUT)
 @pytest.mark.parametrize(
     "snippet,output",
     (
@@ -88,6 +88,13 @@ def pending_kernel_is_ready(jp_serverapp):
 HTML('<p><b>Jupyter</b> rocks.</p>')""",
             '{"output_type": "execute_result", "metadata": {}, "data": {"text/plain": "<IPython.core.display.HTML object>", "text/html": "<p><b>Jupyter</b> rocks.</p>"}, "execution_count": 1}',  # noqa: E501
         ),
+        (
+          "display('a'); print('b')",
+          (
+            '{"output_type": "display_data", "metadata": {}, "data": {"text/plain": "\'a\'"}}'
+            ', {"output_type": "stream", "name": "stdout", "text": "b\\n"}'
+          )
+        )
     ),
 )
 async def test_post_execute(jp_fetch, pending_kernel_is_ready, snippet, output):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,13 @@ source_dir = "src"
 build_dir = "jupyter_server_nbmodel/labextension"
 
 [tool.pytest.ini_options]
+addopts = [
+    "-vv",
+    "-r ap",
+    "--forked",
+    "--cov=jupyter_server_nbmodel",
+    "--cov-fail-under=80",
+]
 filterwarnings = [
   "error",
   "ignore:Unclosed context <zmq.asyncio.Context:ResourceWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,6 @@ source_dir = "src"
 build_dir = "jupyter_server_nbmodel/labextension"
 
 [tool.pytest.ini_options]
-addopts = "-vv --forked"
 filterwarnings = [
   "error",
   "ignore:Unclosed context <zmq.asyncio.Context:ResourceWarning",


### PR DESCRIPTION
- Fixes https://github.com/datalayer/jupyter-server-nbmodel/issues/47
- [x] Add a failing test case (https://github.com/datalayer/jupyter-server-nbmodel/actions/runs/16378348322/job/46283712116#step:7:424):
  ```python
  Traceback (most recent call last):
    File "/home/runner/work/jupyter-server-nbmodel/jupyter-server-nbmodel/jupyter_server_nbmodel/actions.py", line 276, in kernel_worker
      results[uid] = await _execute_snippet(
                     ^^^^^^^^^^^^^^^^^^^^^^^
    File "/home/runner/work/jupyter-server-nbmodel/jupyter-server-nbmodel/jupyter_server_nbmodel/actions.py", line 213, in _execute_snippet
      reply = await ensure_async(
              ^^^^^^^^^^^^^^^^^^^
    File "/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/site-packages/jupyter_core/utils/__init__.py", line 197, in ensure_async
      result = await obj
               ^^^^^^^^^
    File "/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/site-packages/jupyter_client/client.py", line 565, in _async_execute_interactive
      output_hook(msg)
    File "/home/runner/work/jupyter-server-nbmodel/jupyter-server-nbmodel/jupyter_server_nbmodel/actions.py", line 110, in _output_hook
      if (not cell_outputs) or (cell_outputs[-1]["name"] != output["name"]):
                                ~~~~~~~~~~~~~~~~^^^^^^^^
  KeyError: 'name'
  ````
- [x] Add a fix