### PR TITLE
Fix timezone handling in execution timestamps

### DIFF
--- a/jupyter_server_nbmodel/actions.py
+++ b/jupyter_server_nbmodel/actions.py
@@ -231,7 +231,7 @@ async def _execute_snippet(
     if metadata is not None:
         ycell = await _get_ycell(ydoc, metadata)
         if ycell is not None:
-            execution_start_time = datetime.now(timezone.utc).isoformat()[:-6]
+            execution_start_time = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
             # Reset cell
             with ycell.doc.transaction():
                 del ycell["outputs"][:]
@@ -281,7 +281,7 @@ async def _execute_snippet(
         )
     reply_content = reply["content"]
     if ycell is not None:
-        execution_end_time = datetime.now(timezone.utc).isoformat()[:-6]
+        execution_end_time = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
         with ycell.doc.transaction():
             ycell["execution_count"] = reply_content.get("execution_count")
             ycell["execution_state"] = "idle"

--- a/jupyter_server_nbmodel/tests/test_handlers.py
+++ b/jupyter_server_nbmodel/tests/test_handlers.py
@@ -362,8 +362,16 @@ async def test_execution_timing_metadata(jp_root_dir, jp_fetch, pending_kernel_i
     started_time = execution['shell.execute_reply.started']
     reply_time = execution['shell.execute_reply']
 
-    started_dt = datetime.datetime.fromisoformat(started_time)
-    reply_dt = datetime.datetime.fromisoformat(reply_time)
+    # Match jupyter_client UTC serialization (isoformat with Z).
+    assert started_time.endswith("Z"), started_time
+    assert reply_time.endswith("Z"), reply_time
+
+    started_dt = datetime.datetime.fromisoformat(started_time.replace("Z", "+00:00"))
+    reply_dt = datetime.datetime.fromisoformat(reply_time.replace("Z", "+00:00"))
+
+    # Execution timestamps represent UTC and must retain an explicit timezone offset.
+    assert started_dt.utcoffset() == datetime.timedelta(0)
+    assert reply_dt.utcoffset() == datetime.timedelta(0)
 
     # Assert that reply_time is greater than started_time
     assert reply_dt > started_dt, "The reply time is not greater than the started time."


### PR DESCRIPTION
Preserve the UTC offset in execution timing metadata so browsers do not interpret UTC timestamps as local time. Add regression checks ensuring execution timestamps remain timezone-aware

fixes #79 