### PR TITLE
enh: synchroniser to workaround YStore discrampencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,18 +75,109 @@ jupyter labextension list
 
 ### Existing notebooks stop receiving live outputs
 
-We have observed persistent `.jupyter_ystore.db` histories for which the
-browser's Yjs document leaves new server updates pending because their CRDT
-dependencies cannot be resolved. Kernel execution and notebook persistence
-still succeed, but the browser receives no shared-cell change events. The exact
-operation that originally creates this unresolved dependency chain has not yet
-been isolated.
+This issue was initially difficult to distinguish from a kernel message-routing
+problem. On the same server and kernel, a newly created notebook could stream
+normally while an existing notebook executed without displaying anything. A
+server restart alone did not consistently cause or resolve the problem, so the
+important difference was the notebook's persisted collaborative history rather
+than the lifetime of the kernel or server process.
 
-The frontend therefore also reconciles output snapshots returned while polling
-the execution request. This preserves live output for affected notebooks and
-is a no-op when collaborative document updates are healthy. Removing the
-YStore database resets its history, but also discards collaboration history and
-should only be considered after making a backup.
+The debugging sessions produced the following evidence:
+
+- The server received the kernel IOPub messages and its output hook processed
+  them. After execution, the expected stream output was present in the
+  persisted `.ipynb` file. This ruled out a missing kernel message, an incorrect
+  kernel client ID, and a future rejecting messages from another parent ID.
+- Affected browser models emitted no shared-cell change events—not even the
+  prompt updates normally observed during execution—although execution
+  continued on the server.
+- Resolving the active YDoc by notebook path, instead of relying on a possibly
+  stale room ID retained across a restart, fixed one failure mode but did not
+  fix notebooks carrying the problematic history.
+- Removing `jupyter_server_nbmodel` restored JupyterLab's standard
+  kernel-future execution and displayed outputs. Disabling collaboration alone
+  did not restore the server-side execution path, confirming that the failure
+  was in the document/output synchronization used by this extension rather
+  than in the kernel itself.
+- Backing up and removing `.jupyter_ystore.db` restored output updates for the
+  same notebooks. This was the strongest indication that the failure followed
+  persisted YStore state rather than notebook source, kernel state, or a server
+  restart.
+- In the failing state, the browser's Yjs document retained incoming updates in
+  `Y.Doc.store.pendingStructs`. Those updates referenced CRDT dependencies that
+  the browser could not resolve, so they never became observable shared-model
+  changes even though the server could persist the resulting notebook.
+
+The immediate root cause is therefore an unresolved dependency chain in some
+historical YStore documents. The exact earlier operation that first creates
+that chain has not yet been isolated. Stream-output representation was one area
+of concern: nested Yjs text must be integrated through a shared map, and a
+`pycrdt.Text` append must not be wrapped in another document transaction. Those
+operations have been corrected, but they cannot repair invalid history that is
+already stored.
+
+To remain functional with an affected history, execution now uses a primary
+output path plus two recovery layers:
+
+1. Collaborative YDoc updates remain the primary, immediate streaming path.
+2. Every pending `GET /api/kernels/<id>/requests/<uid>` response also contains
+   the outputs accumulated by the server so far. The frontend normalizes
+   consecutive stream chunks and compares the snapshot with the current shared
+   cell. Older or initially empty snapshots are ignored, while a newer stream
+   snapshot appends only its missing text suffix through JupyterLab's output
+   model. It does not replace and recreate the complete rendered output on
+   every poll. Polling backs off to a maximum interval of one second.
+3. The final `200` response reconciles outputs, execution count, and idle state
+   once more. This explains why an earlier version of the recovery displayed
+   output only when execution completed: it only implemented this final step,
+   not the pending snapshots.
+
+The existing execution endpoints also return the request ID, kernel ID, cell
+ID, notebook path, and request state (`queued`, `running`, `input`, or
+`complete`). While an execution is active, its request ID and URL are stored in
+the code cell metadata under `jupyter_server_nbmodel`. After a page refresh, a
+separate restoration plugin reads that metadata and resumes the same
+`GET /api/kernels/<id>/requests/<uid>` poller; no additional discovery endpoint
+is needed. The resumed request also restores the stock JupyterLab kernel
+connection to `busy` until the final response changes it to `idle`. A kernel
+connection created after a refresh intentionally starts as `unknown` and
+cannot replay the `busy` IOPub message emitted before it existed, so the
+frontend feeds the richer REST request state through JupyterLab's normal
+kernel-status update path. This works without the Datalayer UI extension.
+If transient cell metadata has not reached the refreshed browser yet, the
+frontend queries the existing `GET /api/kernels/<id>/execute` route for active
+requests and restores the matching cell poller from the returned request ID,
+URL, notebook path, and cell ID.
+
+Polling reconciliation and the server output hook are both writers to the
+shared document. Before appending a stream chunk, the server therefore compares
+the current shared text with its accumulated kernel output. If the browser has
+already inserted `1234` from a pending response, integrating the corresponding
+server update is a no-op rather than appending the same snapshot and persisting
+`12341234`. This check does not replace or delete integrated output-array
+entries, because restructuring nested Yjs values can expose a transient stream
+without a `text` field while JupyterLab is constructing the cell widget.
+
+Useful browser diagnostics are:
+
+- `[jupyter-server-nbmodel] Received shared cell update` indicates that normal
+  collaborative updates are reaching the cell.
+- `[jupyter-server-nbmodel] Applying pending output snapshot` indicates that
+  the polling fallback found outputs missing from the browser model.
+- `[jupyter-server-nbmodel] Execution completed` reports the number of shared
+  updates and whether final output or execution-count reconciliation was
+  needed.
+
+The Network panel can also be used to inspect the pending `202` responses. Once
+the kernel has emitted output, their JSON bodies should contain a serialized
+`outputs` snapshot. If the server response and persisted `.ipynb` contain the
+output while the browser reports no shared updates, the problem is in document
+synchronization rather than kernel execution.
+
+Removing `.jupyter_ystore.db` resets the stored collaborative history, but it
+also discards that history for every document recorded in the database. Its
+location depends on the Jupyter Server configuration and content root. Stop the
+server and make a backup before using this as a last-resort recovery action.
 
 ## How does it works
 

--- a/README.md
+++ b/README.md
@@ -108,13 +108,111 @@ The debugging sessions produced the following evidence:
   the browser could not resolve, so they never became observable shared-model
   changes even though the server could persist the resulting notebook.
 
-The immediate root cause is therefore an unresolved dependency chain in some
-historical YStore documents. The exact earlier operation that first creates
-that chain has not yet been isolated. Stream-output representation was one area
-of concern: nested Yjs text must be integrated through a shared map, and a
-`pycrdt.Text` append must not be wrapped in another document transaction. Those
-operations have been corrected, but they cannot repair invalid history that is
-already stored.
+There were ultimately three related but distinct failures:
+
+1. Some historical YStore documents contained an unresolved CRDT dependency
+   chain. The browser retained later updates in `Y.Doc.store.pendingStructs`,
+   so the server could save the output while the browser never observed it.
+   The operation that originally created every affected historical chain has
+   not been isolated.
+2. The HTTP recovery made the browser and server concurrent writers to the
+   cell's shared output array. If the browser inserted the accumulated stream
+   `1234` and the server then blindly appended its view of the same stream, the
+   persisted result could become `12341234`. The server now compares the
+   current shared text with its kernel-side accumulator and treats an already
+   applied snapshot as a no-op.
+3. An attempted fix used an array-wide authoritative synchronizer that deleted
+   and replaced integrated output entries. A nested `Map`/`Text` replacement
+   could temporarily expose `{output_type: "stream"}` without `text` to the
+   JavaScript model. JupyterLab then failed in `OutputAreaModel._add` while
+   calling `value.text.join("")`; code-cell construction aborted and the
+   notebook appeared completely empty. That synchronizer was removed. The
+   current hook never replaces or deletes integrated output-array entries.
+
+#### Concrete `pycrdt` checks used during debugging
+
+The following command reproduces the supported stream representation and the
+append operation used by the server. The nested `Text` is first placed in a
+shared `Map`, the `Map` is integrated into a shared `Array`, and `Text.__iadd__`
+owns its transaction. It is intentionally not wrapped in
+`with outputs.doc.transaction()`.
+
+```bash
+python - <<'PY'
+from pycrdt import Array, Doc, Map, Text
+
+server = Doc()
+server_outputs = server.get("outputs", type=Array)
+with server.transaction():
+    server_outputs.append(
+        Map({
+            "output_type": "stream",
+            "name": "stdout",
+            "text": Text("1\n"),
+        })
+    )
+
+browser = Doc()
+browser_outputs = browser.get("outputs", type=Array)
+browser.apply_update(server.get_update())
+server_state = server.get_state()
+
+text = browser_outputs[0]["text"]
+assert isinstance(text, Text)
+text += "2\n"
+server.apply_update(browser.get_update(server_state))
+
+print(repr(str(browser_outputs[0]["text"])))
+print(repr(str(server_outputs[0]["text"])))
+PY
+```
+
+The observed result was:
+
+```text
+'1\n2\n'
+'1\n2\n'
+```
+
+We also reconstructed the real SQLite YStore during the investigation instead
+of assuming that the `.ipynb` file described the browser's CRDT state. The
+important detail is to create typed roots before applying updates:
+
+```bash
+python - <<'PY'
+import sqlite3
+from pycrdt import Array, Doc, Map
+
+database = "/home/echarles/Desktop/notebooks/.jupyter_ystore.db"
+connection = sqlite3.connect(f"file:{database}?mode=ro", uri=True)
+
+for (room,) in connection.execute("SELECT DISTINCT path FROM yupdates"):
+    document = Doc()
+    cells = document.get("cells", type=Array)
+    metadata = document.get("meta", type=Map)
+    state = document.get("state", type=Map)
+
+    updates = connection.execute(
+        "SELECT yupdate FROM yupdates WHERE path = ? ORDER BY timestamp",
+        (room,),
+    )
+    for (update,) in updates:
+        document.apply_update(update)
+
+    print(room, state.to_py().get("path"), len(cells))
+    for index, cell in enumerate(cells):
+        outputs = cell.get("outputs", [])
+        print(index, [output.to_py() for output in outputs])
+PY
+```
+
+This confirmed that the inspected `.ipynb` files still contained their cells
+and that the final reconstructed YStore values had valid stream text. The
+empty-notebook crash came from an invalid transient nested update delivered to
+the live JavaScript model, not from cells being deleted from the notebook file.
+Stopping the server and resetting an already-polluted YStore may still be
+required; correcting the writer prevents creating that state again but cannot
+remove historical updates already stored in the database.
 
 To remain functional with an affected history, execution now uses a primary
 output path plus two recovery layers:

--- a/README.md
+++ b/README.md
@@ -73,6 +73,21 @@ the frontend extension, check the frontend extension is installed:
 jupyter labextension list
 ```
 
+### Existing notebooks stop receiving live outputs
+
+We have observed persistent `.jupyter_ystore.db` histories for which the
+browser's Yjs document leaves new server updates pending because their CRDT
+dependencies cannot be resolved. Kernel execution and notebook persistence
+still succeed, but the browser receives no shared-cell change events. The exact
+operation that originally creates this unresolved dependency chain has not yet
+been isolated.
+
+The frontend therefore also reconciles output snapshots returned while polling
+the execution request. This preserves live output for affected notebooks and
+is a no-op when collaborative document updates are healthy. Removing the
+YStore database resets its history, but also discards collaboration history and
+should only be considered after making a backup.
+
 ## How does it works
 
 ### Generic case
@@ -97,8 +112,9 @@ sequenceDiagram
     loop While status is 202
         Frontend->>+Server: GET /api/kernels/<id>/requests/<uid>
         Server->>ExecutionStack: get() task result
-        ExecutionStack-->>Server: null
-        Server-->>-Frontend: Request status 202
+        ExecutionStack-->>Server: outputs accumulated so far
+        Server-->>-Frontend: Request status 202 & outputs snapshot
+        Frontend->>Shared Document: Reconcile missing output updates
     end
     Kernel-->>Server: Execution reply
     Server->>Shared Document: [𝒏] idle

--- a/jupyter_server_nbmodel/actions.py
+++ b/jupyter_server_nbmodel/actions.py
@@ -99,18 +99,27 @@ def _output_hook(outputs: list[NotebookNode], ycell: y.Map | None, msg: dict) ->
         if ycell is not None:
             cell_outputs = ycell["outputs"]
             if msg_type == "stream":
+                from pycrdt import Map, Text
+
                 with cell_outputs.doc.transaction():
                     text = output["text"]
                     # FIXME Logic is quite complex at https://github.com/jupyterlab/jupyterlab/blob/7ae2d436fc410b0cff51042a3350ba71f54f4445/packages/outputarea/src/model.ts#L518
                     if (not cell_outputs) or (cell_outputs[-1].get("name", None) != output["name"]):
-                        cell_outputs.append(output)
+                        youtput = dict(output)
+                        youtput["text"] = Text(text)
+                        # A nested shared type is only integrated when its
+                        # parent is also a shared type. Appending the plain
+                        # dict would persist the Text value as null.
+                        cell_outputs.append(Map(youtput))
                     else:
                         last_output = cell_outputs[-1]
                         previous_text = last_output["text"]
-                        if isinstance(previous_text, list):
-                            previous_text = "".join(previous_text)
-                        last_output["text"] = previous_text + text
-                        cell_outputs[-1] = last_output
+                        if isinstance(previous_text, Text):
+                            previous_text += text
+                        else:
+                            if isinstance(previous_text, list):
+                                previous_text = "".join(previous_text)
+                            last_output["text"] = Text((previous_text or "") + text)
             else:
                 with cell_outputs.doc.transaction():
                     cell_outputs.append(output)

--- a/jupyter_server_nbmodel/actions.py
+++ b/jupyter_server_nbmodel/actions.py
@@ -115,32 +115,59 @@ def _output_hook(outputs: list[NotebookNode], ycell: y.Map | None, msg: dict) ->
             if msg_type == "stream":
                 from pycrdt import Map, Text
 
-                text = output["text"]
-                # FIXME Logic is quite complex at https://github.com/jupyterlab/jupyterlab/blob/7ae2d436fc410b0cff51042a3350ba71f54f4445/packages/outputarea/src/model.ts#L518
-                if cell_outputs and cell_outputs[-1].get("name", None) == output["name"]:
+                # Derive the authoritative merged stream from the kernel-side
+                # accumulator. The browser fallback may already have inserted
+                # this snapshot in the shared document, in which case this is
+                # intentionally a no-op rather than a second append.
+                expected_parts: list[str] = []
+                for emitted in reversed(outputs):
+                    if (
+                        emitted.get("output_type") != "stream"
+                        or emitted.get("name") != output["name"]
+                    ):
+                        break
+                    emitted_text = emitted.get("text", "")
+                    expected_parts.append(
+                        "".join(emitted_text) if isinstance(emitted_text, list) else emitted_text
+                    )
+                expected_text = "".join(reversed(expected_parts))
+
+                if cell_outputs and cell_outputs[-1].get("name") == output["name"]:
                     last_output = cell_outputs[-1]
                     previous_text = last_output["text"]
+                    actual_text = (
+                        str(previous_text)
+                        if isinstance(previous_text, Text)
+                        else "".join(previous_text)
+                        if isinstance(previous_text, list)
+                        else previous_text or ""
+                    )
+                    if actual_text == expected_text or actual_text.startswith(expected_text):
+                        return
                     if isinstance(previous_text, Text):
-                        # Text.__iadd__ owns its transaction. Nesting it in a
-                        # Doc transaction can leave updates with unresolved
-                        # dependencies in the persistent YStore.
-                        previous_text += text
+                        suffix = (
+                            expected_text[len(actual_text) :]
+                            if expected_text.startswith(actual_text)
+                            else output["text"]
+                        )
+                        previous_text += suffix
                     else:
-                        if isinstance(previous_text, list):
-                            previous_text = "".join(previous_text)
                         with cell_outputs.doc.transaction():
-                            last_output["text"] = Text((previous_text or "") + text)
+                            last_output["text"] = Text(expected_text)
                 else:
                     with cell_outputs.doc.transaction():
                         youtput = dict(output)
-                        youtput["text"] = Text(text)
-                        # A nested shared type is only integrated when its
-                        # parent is also a shared type. Appending the plain
-                        # dict would persist the Text value as null.
+                        youtput["text"] = Text(output["text"])
                         cell_outputs.append(Map(youtput))
             else:
-                with cell_outputs.doc.transaction():
-                    cell_outputs.append(output)
+                # Pending HTTP reconciliation may have inserted this complete
+                # non-stream output before the YDoc update reaches the server.
+                # Avoid persisting the same execute_result/error twice.
+                current = cell_outputs[-1] if cell_outputs else None
+                current_value = current.to_py() if hasattr(current, "to_py") else current
+                if current_value != dict(output):
+                    with cell_outputs.doc.transaction():
+                        cell_outputs.append(output)
     elif msg_type == "clear_output":
         # FIXME msg.content.wait - if true should clear at the next message
         outputs.clear()
@@ -267,6 +294,14 @@ async def _execute_snippet(
                 ycell["execution_state"] = "running"
                 if "execution" in ycell["metadata"]:
                     del ycell["metadata"]["execution"]
+                request_id = metadata.get("request_id")
+                kernel_id = metadata.get("kernel_id")
+                if request_id and kernel_id:
+                    ycell["metadata"]["jupyter_server_nbmodel"] = {
+                        "requestId": request_id,
+                        "kernelId": kernel_id,
+                        "requestUrl": f"/api/kernels/{kernel_id}/requests/{request_id}",
+                    }
                 if metadata.get("record_timing", False):
                     time_info = ycell["metadata"].get("execution", {})
                     time_info["shell.execute_reply.started"] = execution_start_time
@@ -318,6 +353,8 @@ async def _execute_snippet(
         with ycell.doc.transaction():
             ycell["execution_count"] = reply_content.get("execution_count")
             ycell["execution_state"] = "idle"
+            if "jupyter_server_nbmodel" in ycell["metadata"]:
+                del ycell["metadata"]["jupyter_server_nbmodel"]
             if metadata and metadata.get("record_timing", False):
                 if reply_content["status"] == "ok":
                     time_info["shell.execute_reply"] = execution_end_time
@@ -430,11 +467,13 @@ async def kernel_worker(
                 await client.start_channels()
             progress = {"pending": True, "outputs": []}
             results[uid] = progress
+            execution_metadata = dict(metadata or {})
+            execution_metadata.update({"request_id": uid, "kernel_id": kernel_id})
             results[uid] = await _execute_snippet(
                 client,
                 ydoc,
                 snippet,
-                metadata,
+                execution_metadata,
                 partial(_stdin_hook, kernel_id, uid, pending_input),
                 progress,
             )

--- a/jupyter_server_nbmodel/actions.py
+++ b/jupyter_server_nbmodel/actions.py
@@ -43,7 +43,7 @@ async def _get_ycell(
 
     Args:
         ydoc: The YDoc jupyter server extension
-        metadata: Execution context
+        metadata: Execution context, including the notebook path and cell ID
     Returns:
         The cell
     """
@@ -52,16 +52,30 @@ async def _get_ycell(
         get_logger().warning(msg)
         return None
     document_id = metadata.get("document_id")
+    document_path = metadata.get("document_path")
     cell_id = metadata.get("cell_id")
-    if document_id is None or cell_id is None:
+    if (document_id is None and document_path is None) or cell_id is None:
         msg = (
-            "document_id and cell_id not defined. The outputs won't be written within the document."
+            "Neither document_path nor document_id is defined with cell_id. "
+            "The outputs won't be written within the document."
         )
         get_logger().debug(msg)
         return None
-    notebook: YNotebook | None = await ydoc.get_document(room_id=document_id, copy=False)
+    notebook: YNotebook | None = None
+    if isinstance(document_path, str) and document_path:
+        # The document_id is collaborative state and may refer to a room from
+        # before a server restart. Resolve the current live room from the file
+        # path first so updates reach the browser that is actually connected.
+        notebook = await ydoc.get_document(
+            path=document_path,
+            content_type="notebook",
+            file_format="json",
+            copy=False,
+        )
+    if notebook is None and document_id is not None:
+        notebook = await ydoc.get_document(room_id=document_id, copy=False)
     if notebook is None:
-        msg = f"Document with ID {document_id} not found."
+        msg = f"Document at path {document_path!r} with ID {document_id!r} not found."
         get_logger().warning(msg)
         return None
     ycells = filter(lambda c: c["id"] == cell_id, notebook.ycells)
@@ -101,25 +115,29 @@ def _output_hook(outputs: list[NotebookNode], ycell: y.Map | None, msg: dict) ->
             if msg_type == "stream":
                 from pycrdt import Map, Text
 
-                with cell_outputs.doc.transaction():
-                    text = output["text"]
-                    # FIXME Logic is quite complex at https://github.com/jupyterlab/jupyterlab/blob/7ae2d436fc410b0cff51042a3350ba71f54f4445/packages/outputarea/src/model.ts#L518
-                    if (not cell_outputs) or (cell_outputs[-1].get("name", None) != output["name"]):
+                text = output["text"]
+                # FIXME Logic is quite complex at https://github.com/jupyterlab/jupyterlab/blob/7ae2d436fc410b0cff51042a3350ba71f54f4445/packages/outputarea/src/model.ts#L518
+                if cell_outputs and cell_outputs[-1].get("name", None) == output["name"]:
+                    last_output = cell_outputs[-1]
+                    previous_text = last_output["text"]
+                    if isinstance(previous_text, Text):
+                        # Text.__iadd__ owns its transaction. Nesting it in a
+                        # Doc transaction can leave updates with unresolved
+                        # dependencies in the persistent YStore.
+                        previous_text += text
+                    else:
+                        if isinstance(previous_text, list):
+                            previous_text = "".join(previous_text)
+                        with cell_outputs.doc.transaction():
+                            last_output["text"] = Text((previous_text or "") + text)
+                else:
+                    with cell_outputs.doc.transaction():
                         youtput = dict(output)
                         youtput["text"] = Text(text)
                         # A nested shared type is only integrated when its
                         # parent is also a shared type. Appending the plain
                         # dict would persist the Text value as null.
                         cell_outputs.append(Map(youtput))
-                    else:
-                        last_output = cell_outputs[-1]
-                        previous_text = last_output["text"]
-                        if isinstance(previous_text, Text):
-                            previous_text += text
-                        else:
-                            if isinstance(previous_text, list):
-                                previous_text = "".join(previous_text)
-                            last_output["text"] = Text((previous_text or "") + text)
             else:
                 with cell_outputs.doc.transaction():
                     cell_outputs.append(output)
@@ -222,6 +240,7 @@ async def _execute_snippet(
     snippet: str,
     metadata: dict | None,
     stdin_hook: t.Callable[[dict], None] | None,
+    progress: dict[str, t.Any] | None = None,
 ) -> dict[str, t.Any]:
     """Snippet executor
 
@@ -231,6 +250,7 @@ async def _execute_snippet(
         snippet: The code snippet to execute
         metadata: The code snippet metadata; e.g. to define the snippet context
         stdin_hook: The stdin message callback
+        progress: Mutable execution progress exposed by the request status endpoint
     Returns:
         The execution status and outputs.
     """
@@ -264,6 +284,11 @@ async def _execute_snippet(
                 },
             )
     outputs = []
+    if progress is not None:
+        # Keep the same list throughout execution so every output hook is
+        # immediately visible to request polling without copying kernel
+        # messages or waiting for the final execute reply.
+        progress["outputs"] = outputs
     # FIXME we don't check if the session is consistent (aka the kernel is linked to the document)
     #   - should we?
     output_hook = partial(_output_hook, outputs, ycell)
@@ -403,8 +428,15 @@ async def kernel_worker(
             if isinstance(client, GatewayKernelClient) and client.channel_socket is None:
                 get_logger().debug(f"start channels {kernel_id}")
                 await client.start_channels()
+            progress = {"pending": True, "outputs": []}
+            results[uid] = progress
             results[uid] = await _execute_snippet(
-                client, ydoc, snippet, metadata, partial(_stdin_hook, kernel_id, uid, pending_input)
+                client,
+                ydoc,
+                snippet,
+                metadata,
+                partial(_stdin_hook, kernel_id, uid, pending_input),
+                progress,
             )
             get_logger().debug(f"Execution request {uid} processed for kernel {kernel_id}.")
 

--- a/jupyter_server_nbmodel/actions.py
+++ b/jupyter_server_nbmodel/actions.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 import threading
 import typing as t
 from datetime import datetime, timezone
@@ -103,14 +102,14 @@ def _output_hook(outputs: list[NotebookNode], ycell: y.Map | None, msg: dict) ->
                 with cell_outputs.doc.transaction():
                     text = output["text"]
                     # FIXME Logic is quite complex at https://github.com/jupyterlab/jupyterlab/blob/7ae2d436fc410b0cff51042a3350ba71f54f4445/packages/outputarea/src/model.ts#L518
-                    if text.endswith((os.linesep, "\n")):
-                        text = text[:-1]
                     if (not cell_outputs) or (cell_outputs[-1].get("name", None) != output["name"]):
-                        output["text"] = [text]
                         cell_outputs.append(output)
                     else:
                         last_output = cell_outputs[-1]
-                        last_output["text"].append(text)
+                        previous_text = last_output["text"]
+                        if isinstance(previous_text, list):
+                            previous_text = "".join(previous_text)
+                        last_output["text"] = previous_text + text
                         cell_outputs[-1] = last_output
             else:
                 with cell_outputs.doc.transaction():

--- a/jupyter_server_nbmodel/execution_stack.py
+++ b/jupyter_server_nbmodel/execution_stack.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import threading
 import typing as t
 import uuid
@@ -273,6 +274,13 @@ class ExecutionStack:
         result = kernel_results[uid]
         if result == NO_RESULT:
             return None
+        elif isinstance(result, dict) and result.get("pending") is True:
+            # Return a serialized snapshot while retaining the mutable progress
+            # object until the worker replaces it with the final result.
+            return {
+                "pending": True,
+                "outputs": json.dumps(result.get("outputs", [])),
+            }
         else:
             return kernel_results.pop(uid)
 

--- a/jupyter_server_nbmodel/execution_stack.py
+++ b/jupyter_server_nbmodel/execution_stack.py
@@ -70,6 +70,9 @@ class ExecutionStack:
         self.__ydoc = ydoc_extension
         # Store execution results per kernelID per execution request ID
         self.__execution_results: dict[str, dict[str, t.Any]] = {}
+        # Keep request metadata until its result is consumed so every response
+        # can describe the request restored from notebook cell metadata.
+        self.__execution_metadata: dict[str, dict[str, dict | None]] = {}
         # Cache kernel clients
         self.__kernel_clients: dict[str, t.Any] = {}
         # Connection information for kernels hosted by a remote Jupyter server.
@@ -181,6 +184,7 @@ class ExecutionStack:
                 client.context.destroy(linger=0)
         self.__kernel_clients.clear()
         self.__remote_servers.clear()
+        self.__execution_metadata.clear()
         get_logger().debug("ExecutionStack has been disposed.")
 
     async def cancel(self, kernel_id: str, timeout: float | None = None) -> None:
@@ -262,6 +266,17 @@ class ExecutionStack:
         if uid not in kernel_results:
             raise ValueError(f"Execution request {uid} for kernel {kernel_id} does not exists.")
 
+        metadata = self.__execution_metadata.get(kernel_id, {}).get(uid)
+        request_context = {
+            "request_id": uid,
+            "kernel_id": kernel_id,
+            "request_url": f"/api/kernels/{kernel_id}/requests/{uid}",
+            "cell_id": metadata.get("cell_id") if isinstance(metadata, dict) else None,
+            "document_path": (
+                metadata.get("document_path") if isinstance(metadata, dict) else None
+            ),
+        }
+
         if self.__pending_inputs[kernel_id].is_pending():
             get_logger().info(f"Kernel '{kernel_id}' has a pending input.")
             # Check the request id is the one matching the appearance of the input
@@ -269,20 +284,65 @@ class ExecutionStack:
             # pending input
             input_ = self.__pending_inputs[kernel_id]
             if uid == input_.request_id:
-                return asdict(input_.content)
+                return {
+                    **asdict(input_.content),
+                    **request_context,
+                    "pending": True,
+                    "request_status": "input",
+                }
 
         result = kernel_results[uid]
         if result == NO_RESULT:
-            return None
+            return {
+                **request_context,
+                "pending": True,
+                "request_status": "queued",
+                "outputs": "[]",
+            }
         elif isinstance(result, dict) and result.get("pending") is True:
             # Return a serialized snapshot while retaining the mutable progress
             # object until the worker replaces it with the final result.
             return {
+                **request_context,
                 "pending": True,
+                "request_status": "running",
                 "outputs": json.dumps(result.get("outputs", [])),
             }
         else:
-            return kernel_results.pop(uid)
+            self.__execution_metadata.get(kernel_id, {}).pop(uid, None)
+            return {
+                **kernel_results.pop(uid),
+                **request_context,
+                "pending": False,
+                "request_status": "complete",
+            }
+
+    def pending(self, kernel_id: str) -> list[dict[str, t.Any]]:
+        """Describe active requests without consuming their final results."""
+        requests: list[dict[str, t.Any]] = []
+        for uid, result in self.__execution_results.get(kernel_id, {}).items():
+            metadata = self.__execution_metadata.get(kernel_id, {}).get(uid)
+            context = {
+                "request_id": uid,
+                "kernel_id": kernel_id,
+                "request_url": f"/api/kernels/{kernel_id}/requests/{uid}",
+                "cell_id": metadata.get("cell_id") if isinstance(metadata, dict) else None,
+                "document_path": (
+                    metadata.get("document_path") if isinstance(metadata, dict) else None
+                ),
+                "pending": True,
+            }
+            if result == NO_RESULT:
+                requests.append({**context, "request_status": "queued", "outputs": "[]"})
+            elif isinstance(result, dict) and result.get("pending") is True:
+                requests.append(
+                    {
+                        **context,
+                        "request_status": "running",
+                        "outputs": json.dumps(result.get("outputs", [])),
+                    }
+                )
+        return requests
 
     def put(
         self,
@@ -309,8 +369,11 @@ class ExecutionStack:
 
         if kernel_id not in self.__execution_results:
             self.__execution_results[kernel_id] = {}
+        if kernel_id not in self.__execution_metadata:
+            self.__execution_metadata[kernel_id] = {}
         # Make the stack aware a request `uid` exists.
         self.__execution_results[kernel_id][uid] = NO_RESULT
+        self.__execution_metadata[kernel_id][uid] = metadata
         if kernel_id not in self.__pending_inputs:
             self.__pending_inputs[kernel_id] = PendingInput()
         if kernel_id not in self.__tasks:

--- a/jupyter_server_nbmodel/extension.py
+++ b/jupyter_server_nbmodel/extension.py
@@ -10,13 +10,8 @@ from jupyter_server.extension.application import ExtensionApp
 from jupyter_server.services.kernels.handlers import _kernel_id_regex
 
 from jupyter_server_nbmodel.execution_stack import ExecutionStack
-from jupyter_server_nbmodel.handlers import (
-    ExecuteHandler,
-    InputHandler,
-    RequestHandler,
-)
+from jupyter_server_nbmodel.handlers import ExecuteHandler, InputHandler, RequestHandler
 from jupyter_server_nbmodel.log import get_logger
-
 
 RTC_EXTENSIONAPP_NAME = "jupyter_server_ydoc"
 

--- a/jupyter_server_nbmodel/handlers.py
+++ b/jupyter_server_nbmodel/handlers.py
@@ -30,6 +30,18 @@ class ExecuteHandler(ExtensionHandlerMixin, APIHandler):
         self._execution_stack = execution_stack
 
     @tornado.web.authenticated
+    def get(self, kernel_id: str) -> None:
+        """Return active executions for the kernel without consuming them."""
+        self.finish(
+            json.dumps(
+                {
+                    "kernel_id": kernel_id,
+                    "requests": self._execution_stack.pending(kernel_id),
+                }
+            )
+        )
+
+    @tornado.web.authenticated
     async def post(self, kernel_id: str) -> None:
         """
         Execute a code snippet within the kernel
@@ -70,9 +82,23 @@ class ExecuteHandler(ExtensionHandlerMixin, APIHandler):
             get_logger().error(msg)
             raise tornado.web.HTTPError(status_code=HTTPStatus.NOT_FOUND, reason=msg)
         uid = self._execution_stack.put(kernel_id, snippet, metadata, remote_server=remote_server)
+        location = f"/api/kernels/{kernel_id}/requests/{uid}"
         self.set_status(HTTPStatus.ACCEPTED)
-        self.set_header("Location", f"/api/kernels/{kernel_id}/requests/{uid}")
-        self.finish("{}")
+        self.set_header("Location", location)
+        self.finish(
+            json.dumps(
+                {
+                    "request_id": uid,
+                    "kernel_id": kernel_id,
+                    "cell_id": metadata.get("cell_id"),
+                    "document_path": metadata.get("document_path"),
+                    "pending": True,
+                    "request_status": "queued",
+                    "request_url": location,
+                    "outputs": "[]",
+                }
+            )
+        )
 
 
 class InputHandler(ExtensionHandlerMixin, APIHandler):
@@ -143,14 +169,14 @@ class RequestHandler(ExtensionHandlerMixin, APIHandler):
                 self.set_status(202)
                 self.finish("{}")
             else:
-                if r.get("pending") is True:
-                    self.set_status(202)
-                elif "error" in r:
+                if "error" in r:
                     self.set_status(500)
                     self.log.debug(f"{r}")
                 elif "input_request" in r:
                     self.set_status(300)
                     self.set_header("Location", f"/api/kernels/{kernel_id}/input")
+                elif r.get("pending") is True:
+                    self.set_status(202)
                 else:
                     self.set_status(200)
                 self.finish(json.dumps(r))

--- a/jupyter_server_nbmodel/handlers.py
+++ b/jupyter_server_nbmodel/handlers.py
@@ -143,7 +143,9 @@ class RequestHandler(ExtensionHandlerMixin, APIHandler):
                 self.set_status(202)
                 self.finish("{}")
             else:
-                if "error" in r:
+                if r.get("pending") is True:
+                    self.set_status(202)
+                elif "error" in r:
                     self.set_status(500)
                     self.log.debug(f"{r}")
                 elif "input_request" in r:

--- a/jupyter_server_nbmodel/tests/test_actions.py
+++ b/jupyter_server_nbmodel/tests/test_actions.py
@@ -33,14 +33,20 @@ def test_output_hook_preserves_stream_newlines() -> None:
 
 def test_output_hook_appends_to_reloaded_stream_text() -> None:
     """A stream loaded as collaborative Text remains writable after restart."""
-    doc = Doc()
-    persisted = doc.get("outputs", type=Array)
-    ycell = {"outputs": persisted}
+    original_doc = Doc()
+    original_outputs = original_doc.get("outputs", type=Array)
+    _output_hook([], {"outputs": original_outputs}, _stream_message("before restart\n"))
 
-    _output_hook([], ycell, _stream_message("before restart\n"))
-    _output_hook([], ycell, _stream_message("after restart\n"))
+    reloaded_doc = Doc()
+    reloaded_doc.apply_update(original_doc.get_update())
+    reloaded_outputs = reloaded_doc.get("outputs", type=Array)
+    peer_state = original_doc.get_state()
 
-    assert str(persisted[0]["text"]) == "before restart\nafter restart\n"
+    _output_hook([], {"outputs": reloaded_outputs}, _stream_message("after restart\n"))
+    original_doc.apply_update(reloaded_doc.get_update(peer_state))
+
+    assert str(reloaded_outputs[0]["text"]) == "before restart\nafter restart\n"
+    assert str(original_outputs[0]["text"]) == "before restart\nafter restart\n"
 
 
 async def test_dedup_task_queue_empty():

--- a/jupyter_server_nbmodel/tests/test_actions.py
+++ b/jupyter_server_nbmodel/tests/test_actions.py
@@ -1,8 +1,42 @@
 """Unit tests for execution actions."""
 
 import asyncio
+from contextlib import nullcontext
 
-from jupyter_server_nbmodel.actions import dedup_task_queue
+from jupyter_server_nbmodel.actions import _output_hook, dedup_task_queue
+
+
+class _Outputs(list):
+    """Minimal shared output array used to exercise streaming persistence."""
+
+    class _Doc:
+        @staticmethod
+        def transaction():
+            return nullcontext()
+
+    doc = _Doc()
+
+
+def _stream_message(text: str) -> dict:
+    return {
+        "header": {"msg_type": "stream"},
+        "content": {"name": "stdout", "text": text},
+    }
+
+
+def test_output_hook_preserves_stream_newlines() -> None:
+    """Merged stream chunks retain separators when the notebook is reloaded."""
+    emitted = []
+    persisted = _Outputs()
+    ycell = {"outputs": persisted}
+
+    _output_hook(emitted, ycell, _stream_message("1\n"))
+    _output_hook(emitted, ycell, _stream_message("2\n"))
+
+    assert persisted == [
+        {"output_type": "stream", "name": "stdout", "text": "1\n2\n"}
+    ]
+    assert persisted[0]["text"] == "1\n2\n"
 
 
 async def test_dedup_task_queue_empty():

--- a/jupyter_server_nbmodel/tests/test_actions.py
+++ b/jupyter_server_nbmodel/tests/test_actions.py
@@ -1,20 +1,10 @@
 """Unit tests for execution actions."""
 
 import asyncio
-from contextlib import nullcontext
+
+from pycrdt import Array, Doc, Text
 
 from jupyter_server_nbmodel.actions import _output_hook, dedup_task_queue
-
-
-class _Outputs(list):
-    """Minimal shared output array used to exercise streaming persistence."""
-
-    class _Doc:
-        @staticmethod
-        def transaction():
-            return nullcontext()
-
-    doc = _Doc()
 
 
 def _stream_message(text: str) -> dict:
@@ -27,16 +17,30 @@ def _stream_message(text: str) -> dict:
 def test_output_hook_preserves_stream_newlines() -> None:
     """Merged stream chunks retain separators when the notebook is reloaded."""
     emitted = []
-    persisted = _Outputs()
+    doc = Doc()
+    persisted = doc.get("outputs", type=Array)
     ycell = {"outputs": persisted}
 
     _output_hook(emitted, ycell, _stream_message("1\n"))
     _output_hook(emitted, ycell, _stream_message("2\n"))
 
-    assert persisted == [
-        {"output_type": "stream", "name": "stdout", "text": "1\n2\n"}
-    ]
-    assert persisted[0]["text"] == "1\n2\n"
+    assert len(persisted) == 1
+    assert persisted[0]["output_type"] == "stream"
+    assert persisted[0]["name"] == "stdout"
+    assert isinstance(persisted[0]["text"], Text)
+    assert str(persisted[0]["text"]) == "1\n2\n"
+
+
+def test_output_hook_appends_to_reloaded_stream_text() -> None:
+    """A stream loaded as collaborative Text remains writable after restart."""
+    doc = Doc()
+    persisted = doc.get("outputs", type=Array)
+    ycell = {"outputs": persisted}
+
+    _output_hook([], ycell, _stream_message("before restart\n"))
+    _output_hook([], ycell, _stream_message("after restart\n"))
+
+    assert str(persisted[0]["text"]) == "before restart\nafter restart\n"
 
 
 async def test_dedup_task_queue_empty():

--- a/jupyter_server_nbmodel/tests/test_actions.py
+++ b/jupyter_server_nbmodel/tests/test_actions.py
@@ -32,21 +32,39 @@ def test_output_hook_preserves_stream_newlines() -> None:
 
 
 def test_output_hook_appends_to_reloaded_stream_text() -> None:
-    """A stream loaded as collaborative Text remains writable after restart."""
+    """A stream loaded as collaborative Text remains writable after reload."""
+    emitted = []
     original_doc = Doc()
     original_outputs = original_doc.get("outputs", type=Array)
-    _output_hook([], {"outputs": original_outputs}, _stream_message("before restart\n"))
+    _output_hook(emitted, {"outputs": original_outputs}, _stream_message("before reload\n"))
 
     reloaded_doc = Doc()
     reloaded_doc.apply_update(original_doc.get_update())
     reloaded_outputs = reloaded_doc.get("outputs", type=Array)
     peer_state = original_doc.get_state()
 
-    _output_hook([], {"outputs": reloaded_outputs}, _stream_message("after restart\n"))
+    _output_hook(emitted, {"outputs": reloaded_outputs}, _stream_message("after reload\n"))
     original_doc.apply_update(reloaded_doc.get_update(peer_state))
 
-    assert str(reloaded_outputs[0]["text"]) == "before restart\nafter restart\n"
-    assert str(original_outputs[0]["text"]) == "before restart\nafter restart\n"
+    assert str(reloaded_outputs[0]["text"]) == "before reload\nafter reload\n"
+    assert str(original_outputs[0]["text"]) == "before reload\nafter reload\n"
+
+
+def test_output_hook_does_not_append_browser_snapshot_twice() -> None:
+    """A snapshot already inserted by polling remains unchanged by the hook."""
+    emitted = []
+    doc = Doc()
+    persisted = doc.get("outputs", type=Array)
+    ycell = {"outputs": persisted}
+
+    _output_hook(emitted, ycell, _stream_message("1\n"))
+    # Simulate the browser fallback applying the next accumulated snapshot
+    # before the matching collaborative hook is integrated locally.
+    persisted[0]["text"] += "2\n"
+    _output_hook(emitted, ycell, _stream_message("2\n"))
+
+    assert len(persisted) == 1
+    assert str(persisted[0]["text"]) == "1\n2\n"
 
 
 async def test_dedup_task_queue_empty():

--- a/jupyter_server_nbmodel/tests/test_handlers.py
+++ b/jupyter_server_nbmodel/tests/test_handlers.py
@@ -152,7 +152,7 @@ async def test_post_execute_no_ycell(jp_fetch, pending_kernel_is_ready, snippet,
     (
         (
             "print('hello buddy')",
-            '{"output_type": "stream", "name": "stdout", "text": ["hello buddy"]}',
+            '{"output_type": "stream", "name": "stdout", "text": "hello buddy\\n"}',
         ),
         ("a = 1", ""),
         (
@@ -164,7 +164,7 @@ HTML('<p><b>Jupyter</b> rocks.</p>')""",
           "display('a'); print('b')",
           (
             '{"output_type": "display_data", "metadata": {}, "data": {"text/plain": "\'a\'"}}'
-            ', {"output_type": "stream", "name": "stdout", "text": ["b"]}'
+            ', {"output_type": "stream", "name": "stdout", "text": "b\\n"}'
           )
         )
     ),

--- a/jupyter_server_nbmodel/tests/test_handlers.py
+++ b/jupyter_server_nbmodel/tests/test_handlers.py
@@ -6,13 +6,14 @@ import asyncio
 import datetime
 import json
 import re
-import nbformat
 
+import nbformat
 import pytest
-from jupyter_client.kernelspec import NATIVE_KERNEL_NAME
 from jupyter_client.asynchronous.client import AsyncKernelClient
-from jupyter_server_nbmodel.models import PendingInput
+from jupyter_client.kernelspec import NATIVE_KERNEL_NAME
+
 from jupyter_server_nbmodel.actions import kernel_worker
+from jupyter_server_nbmodel.models import PendingInput
 
 TEST_TIMEOUT = 15
 
@@ -146,6 +147,66 @@ async def test_post_execute_no_ycell(jp_fetch, pending_kernel_is_ready, snippet,
     await asyncio.sleep(1)
 
 
+@pytest.mark.timeout(TEST_TIMEOUT)
+async def test_pending_execute_returns_stream_outputs(jp_fetch, pending_kernel_is_ready):
+    """Pending request polling exposes output before execution completes."""
+    response = await jp_fetch(
+        "api", "kernels", method="POST", body=json.dumps({"name": NATIVE_KERNEL_NAME})
+    )
+    kernel = json.loads(response.body.decode())
+    await pending_kernel_is_ready(kernel["id"])
+
+    response = await jp_fetch(
+        "api",
+        "kernels",
+        kernel["id"],
+        "execute",
+        method="POST",
+        body=json.dumps(
+            {
+                "code": (
+                    "import time\n"
+                    "print('streamed before completion', flush=True)\n"
+                    "time.sleep(1.5)\n"
+                    "print('completed', flush=True)"
+                )
+            }
+        ),
+    )
+    assert response.code == 202
+    location = response.headers["Location"]
+
+    pending_outputs = []
+    for _ in range(10):
+        await asyncio.sleep(0.1)
+        response = await jp_fetch(location, raise_error=False)
+        assert response.code == 202, "Execution completed before its stream was observed."
+        payload = json.loads(response.body)
+        if "outputs" in payload:
+            pending_outputs = json.loads(payload["outputs"])
+        if pending_outputs:
+            break
+
+    assert pending_outputs == [
+        {
+            "output_type": "stream",
+            "name": "stdout",
+            "text": "streamed before completion\n",
+        }
+    ]
+
+    response = await _wait_request(jp_fetch, location)
+    assert response.code == 200
+    final_outputs = json.loads(json.loads(response.body)["outputs"])
+    assert "".join(output["text"] for output in final_outputs) == (
+        "streamed before completion\ncompleted\n"
+    )
+
+    response = await jp_fetch("api", "kernels", kernel["id"], method="DELETE")
+    assert response.code == 204
+    await asyncio.sleep(1)
+
+
 @pytest.mark.timeout(2 * TEST_TIMEOUT)
 @pytest.mark.parametrize(
     "snippet,output",
@@ -169,7 +230,9 @@ HTML('<p><b>Jupyter</b> rocks.</p>')""",
         )
     ),
 )
-async def test_post_execute_with_ycell(jp_fetch, pending_kernel_is_ready, snippet, output, rtc_test_notebook):
+async def test_post_execute_with_ycell(
+    jp_fetch, pending_kernel_is_ready, snippet, output, rtc_test_notebook
+):
     r = await jp_fetch(
         "api", "kernels", method="POST", body=json.dumps({"name": NATIVE_KERNEL_NAME})
     )
@@ -195,7 +258,10 @@ async def test_post_execute_with_ycell(jp_fetch, pending_kernel_is_ready, snippe
             "code": snippet,
             "metadata": {
                 "cell_id": cell_id,
-                "document_id": document_id
+                # A restored notebook can retain a room ID from before the
+                # server restart. The path must select the active room.
+                "document_id": f"{document_id}-stale",
+                "document_path": "test.ipynb"
             }
         }),
     )
@@ -276,7 +342,7 @@ async def test_post_erroneous_execute(jp_fetch, pending_kernel_is_ready, snippet
 @pytest.mark.asyncio
 async def test_kernel_worker_reports_error(monkeypatch):
     # Patch _execute_snippet to raise an error
-    async def fake_execute(client, ydoc, snippet, metadata, stdin_hook):
+    async def fake_execute(client, ydoc, snippet, metadata, stdin_hook, progress=None):
         raise RuntimeError("simulated failure")
     monkeypatch.setattr(
         "jupyter_server_nbmodel.actions._execute_snippet",
@@ -314,7 +380,13 @@ async def test_kernel_worker_reports_error(monkeypatch):
 
 
 @pytest.mark.timeout(TEST_TIMEOUT)
-async def test_execution_timing_metadata(jp_root_dir, jp_fetch, pending_kernel_is_ready, rtc_test_notebook, jp_serverapp):
+async def test_execution_timing_metadata(
+    jp_root_dir,
+    jp_fetch,
+    pending_kernel_is_ready,
+    rtc_test_notebook,
+    jp_serverapp,
+):
     snippet = "a = 1"
     nb = nbformat.v4.new_notebook(
         cells=[nbformat.v4.new_code_cell(source=snippet, execution_count=1)]
@@ -356,7 +428,9 @@ async def test_execution_timing_metadata(jp_root_dir, jp_fetch, pending_kernel_i
 
     # Assert that start and end time exist in 'execution'
     execution = cell_data['metadata']['execution']
-    assert 'shell.execute_reply.started' in execution, "'shell.execute_reply.started' does not exist in 'execution'"
+    assert "shell.execute_reply.started" in execution, (
+        "'shell.execute_reply.started' does not exist in 'execution'"
+    )
     assert 'shell.execute_reply' in execution, "'shell.execute_reply' does not exist in 'execution'"
 
     started_time = execution['shell.execute_reply.started']

--- a/jupyter_server_nbmodel/tests/test_handlers.py
+++ b/jupyter_server_nbmodel/tests/test_handlers.py
@@ -99,12 +99,13 @@ def rtc_test_notebook(jp_serverapp, rtc_create_notebook):
         assert path == returned_path
         document_id = get_document_id(jp_serverapp, "test.ipynb")
         return document_id
+
     return _
 
 
 def get_document_id(jp_serverapp, notebook_name):
     fim = jp_serverapp.web_app.settings["file_id_manager"]
-    document_id = f'json:notebook:{fim.get_id(notebook_name)}'
+    document_id = f"json:notebook:{fim.get_id(notebook_name)}"
     return document_id
 
 
@@ -148,8 +149,22 @@ async def test_post_execute_no_ycell(jp_fetch, pending_kernel_is_ready, snippet,
 
 
 @pytest.mark.timeout(TEST_TIMEOUT)
-async def test_pending_execute_returns_stream_outputs(jp_fetch, pending_kernel_is_ready):
+async def test_pending_execute_returns_stream_outputs(
+    jp_fetch,
+    pending_kernel_is_ready,
+    rtc_test_notebook,
+    jp_serverapp,
+):
     """Pending request polling exposes output before execution completes."""
+    snippet = (
+        "import time\n"
+        "print('streamed before completion', flush=True)\n"
+        "time.sleep(1.5)\n"
+        "print('completed', flush=True)"
+    )
+    notebook = nbformat.v4.new_notebook(cells=[nbformat.v4.new_code_cell(source=snippet)])
+    document_id = await rtc_test_notebook(notebook)
+    cell_id = notebook["cells"][0]["id"]
     response = await jp_fetch(
         "api", "kernels", method="POST", body=json.dumps({"name": NATIVE_KERNEL_NAME})
     )
@@ -164,17 +179,29 @@ async def test_pending_execute_returns_stream_outputs(jp_fetch, pending_kernel_i
         method="POST",
         body=json.dumps(
             {
-                "code": (
-                    "import time\n"
-                    "print('streamed before completion', flush=True)\n"
-                    "time.sleep(1.5)\n"
-                    "print('completed', flush=True)"
-                )
+                "code": snippet,
+                "metadata": {
+                    "cell_id": cell_id,
+                    "document_id": document_id,
+                    "document_path": "test.ipynb",
+                },
             }
         ),
     )
     assert response.code == 202
     location = response.headers["Location"]
+    accepted = json.loads(response.body)
+    request_id = location.rsplit("/", 1)[-1]
+    assert accepted == {
+        "request_id": request_id,
+        "kernel_id": kernel["id"],
+        "cell_id": cell_id,
+        "document_path": "test.ipynb",
+        "pending": True,
+        "request_status": "queued",
+        "request_url": location,
+        "outputs": "[]",
+    }
 
     pending_outputs = []
     for _ in range(10):
@@ -182,6 +209,11 @@ async def test_pending_execute_returns_stream_outputs(jp_fetch, pending_kernel_i
         response = await jp_fetch(location, raise_error=False)
         assert response.code == 202, "Execution completed before its stream was observed."
         payload = json.loads(response.body)
+        assert payload["request_id"] == request_id
+        assert payload["kernel_id"] == kernel["id"]
+        assert payload["request_url"] == location
+        assert payload["pending"] is True
+        assert payload["request_status"] in {"queued", "running"}
         if "outputs" in payload:
             pending_outputs = json.loads(payload["outputs"])
         if pending_outputs:
@@ -194,13 +226,45 @@ async def test_pending_execute_returns_stream_outputs(jp_fetch, pending_kernel_i
             "text": "streamed before completion\n",
         }
     ]
+    response = await jp_fetch("api", "kernels", kernel["id"], "execute")
+    assert response.code == 200
+    active = json.loads(response.body)
+    assert active["kernel_id"] == kernel["id"]
+    assert active["requests"] == [
+        {
+            "request_id": request_id,
+            "kernel_id": kernel["id"],
+            "request_url": location,
+            "cell_id": cell_id,
+            "document_path": "test.ipynb",
+            "pending": True,
+            "request_status": "running",
+            "outputs": json.dumps(pending_outputs),
+        }
+    ]
+    collaboration = jp_serverapp.web_app.settings["jupyter_server_ydoc"]
+    document = await collaboration.get_document(
+        path="test.ipynb", content_type="notebook", file_format="json", copy=False
+    )
+    assert document.get()["cells"][0]["metadata"]["jupyter_server_nbmodel"] == {
+        "requestId": request_id,
+        "kernelId": kernel["id"],
+        "requestUrl": location,
+    }
 
     response = await _wait_request(jp_fetch, location)
     assert response.code == 200
-    final_outputs = json.loads(json.loads(response.body)["outputs"])
+    final_payload = json.loads(response.body)
+    assert final_payload["request_id"] == request_id
+    assert final_payload["kernel_id"] == kernel["id"]
+    assert final_payload["request_url"] == location
+    assert final_payload["pending"] is False
+    assert final_payload["request_status"] == "complete"
+    final_outputs = json.loads(final_payload["outputs"])
     assert "".join(output["text"] for output in final_outputs) == (
         "streamed before completion\ncompleted\n"
     )
+    assert "jupyter_server_nbmodel" not in document.get()["cells"][0]["metadata"]
 
     response = await jp_fetch("api", "kernels", kernel["id"], method="DELETE")
     assert response.code == 204
@@ -222,12 +286,12 @@ HTML('<p><b>Jupyter</b> rocks.</p>')""",
             '{"output_type": "execute_result", "metadata": {}, "data": {"text/plain": "<IPython.core.display.HTML object>", "text/html": "<p><b>Jupyter</b> rocks.</p>"}, "execution_count": 1}',  # noqa: E501
         ),
         (
-          "display('a'); print('b')",
-          (
-            '{"output_type": "display_data", "metadata": {}, "data": {"text/plain": "\'a\'"}}'
-            ', {"output_type": "stream", "name": "stdout", "text": "b\\n"}'
-          )
-        )
+            "display('a'); print('b')",
+            (
+                '{"output_type": "display_data", "metadata": {}, "data": {"text/plain": "\'a\'"}}'
+                ', {"output_type": "stream", "name": "stdout", "text": "b\\n"}'
+            ),
+        ),
     ),
 )
 async def test_post_execute_with_ycell(
@@ -239,9 +303,7 @@ async def test_post_execute_with_ycell(
     kernel = json.loads(r.body.decode())
     await pending_kernel_is_ready(kernel["id"])
 
-    nb = nbformat.v4.new_notebook(
-        cells=[nbformat.v4.new_code_cell(source=snippet)]
-    )
+    nb = nbformat.v4.new_notebook(cells=[nbformat.v4.new_code_cell(source=snippet)])
     document_id = await rtc_test_notebook(nb)
     cell_id = nb["cells"][0]["id"]
 
@@ -254,16 +316,18 @@ async def test_post_execute_with_ycell(
         timeout=2 * TEST_TIMEOUT,
         retries=1,
         method="POST",
-        body=json.dumps({
-            "code": snippet,
-            "metadata": {
-                "cell_id": cell_id,
-                # A restored notebook can retain a room ID from before the
-                # server restart. The path must select the active room.
-                "document_id": f"{document_id}-stale",
-                "document_path": "test.ipynb"
+        body=json.dumps(
+            {
+                "code": snippet,
+                "metadata": {
+                    "cell_id": cell_id,
+                    # A restored notebook can retain a room ID from before the
+                    # server restart. The path must select the active room.
+                    "document_id": f"{document_id}-stale",
+                    "document_path": "test.ipynb",
+                },
             }
-        }),
+        ),
     )
 
     assert response.code == 200
@@ -292,8 +356,8 @@ async def test_post_execute_with_ycell(
                     "---------------------------------------------------------------------------",
                     "ZeroDivisionError                         Traceback (most recent call last)",
                     "Cell In[1], line 1\n----> 1 1 / 0\n",
-                    "ZeroDivisionError: division by zero"
-                ]
+                    "ZeroDivisionError: division by zero",
+                ],
             },
         ),
     ),
@@ -319,17 +383,13 @@ async def test_post_erroneous_execute(jp_fetch, pending_kernel_is_ready, snippet
     assert response.code == 200
     payload = json.loads(response.body)
     outputs = payload["outputs"]
-    del payload["outputs"]
-    assert payload == {
-        "status": "error",
-        "execution_count": 1
-    }
+    assert payload["status"] == "error"
+    assert payload["execution_count"] == 1
+    assert payload["pending"] is False
+    assert payload["request_status"] == "complete"
     outputs = json.loads(outputs)
     for output in outputs:
-        output["traceback"] = [
-            strip_ansi(line)
-            for line in output["traceback"]
-        ]
+        output["traceback"] = [strip_ansi(line) for line in output["traceback"]]
 
     assert outputs == [output]
 
@@ -344,6 +404,7 @@ async def test_kernel_worker_reports_error(monkeypatch):
     # Patch _execute_snippet to raise an error
     async def fake_execute(client, ydoc, snippet, metadata, stdin_hook, progress=None):
         raise RuntimeError("simulated failure")
+
     monkeypatch.setattr(
         "jupyter_server_nbmodel.actions._execute_snippet",
         fake_execute,
@@ -409,14 +470,12 @@ async def test_execution_timing_metadata(
         kernel["id"],
         "execute",
         method="POST",
-        body=json.dumps({
-            "code": snippet,
-            "metadata": {
-                "cell_id": cell_id,
-                "document_id": document_id,
-                "record_timing": True
+        body=json.dumps(
+            {
+                "code": snippet,
+                "metadata": {"cell_id": cell_id, "document_id": document_id, "record_timing": True},
             }
-        }),
+        ),
     )
     assert response.code == 200
 
@@ -424,17 +483,17 @@ async def test_execution_timing_metadata(
         path=path, content_type="notebook", file_format="json", copy=False
     )
     cell_data = document.get()["cells"][0]
-    assert 'execution' in cell_data['metadata'], "'execution' does not exist in 'metadata'"
+    assert "execution" in cell_data["metadata"], "'execution' does not exist in 'metadata'"
 
     # Assert that start and end time exist in 'execution'
-    execution = cell_data['metadata']['execution']
+    execution = cell_data["metadata"]["execution"]
     assert "shell.execute_reply.started" in execution, (
         "'shell.execute_reply.started' does not exist in 'execution'"
     )
-    assert 'shell.execute_reply' in execution, "'shell.execute_reply' does not exist in 'execution'"
+    assert "shell.execute_reply" in execution, "'shell.execute_reply' does not exist in 'execution'"
 
-    started_time = execution['shell.execute_reply.started']
-    reply_time = execution['shell.execute_reply']
+    started_time = execution["shell.execute_reply.started"]
+    reply_time = execution["shell.execute_reply"]
 
     started_dt = datetime.datetime.fromisoformat(started_time)
     reply_dt = datetime.datetime.fromisoformat(reply_time)
@@ -481,11 +540,18 @@ async def test_post_input_execute(jp_fetch, pending_kernel_is_ready):
     response4 = await _wait_request(jp_fetch, location)
     assert response4.code == 200
     payload2 = json.loads(response4.body)
-    assert payload2 == {
-        "status": "ok",
-        "execution_count": 1,
-        "outputs": '[{"output_type": "execute_result", "metadata": {}, "data": {"text/plain": "\'42\'"}, "execution_count": 1}]',  # noqa: E501
-    }
+    assert payload2["status"] == "ok"
+    assert payload2["execution_count"] == 1
+    assert payload2["pending"] is False
+    assert payload2["request_status"] == "complete"
+    assert json.loads(payload2["outputs"]) == [
+        {
+            "output_type": "execute_result",
+            "metadata": {},
+            "data": {"text/plain": "'42'"},
+            "execution_count": 1,
+        }
+    ]
 
     r2 = await jp_fetch("api", "kernels", kernel["id"], method="DELETE")
     assert r2.code == 204

--- a/src/__tests__/jupyter_server_nbmodel.spec.ts
+++ b/src/__tests__/jupyter_server_nbmodel.spec.ts
@@ -4,12 +4,148 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-/**
- * Example of [Jest](https://jestjs.io/docs/getting-started) unit tests
- */
+import type { CodeCell } from '@jupyterlab/cells';
+import {
+  clearServerExecutionMetadata,
+  getServerExecutionMetadata,
+  setServerExecutionMetadata
+} from '../executionMetadata';
+import {
+  isOutputPrefix,
+  reconcileOutputSnapshot
+} from '../outputReconciliation';
+import { restoreKernelModelStatus, restoreKernelStatus } from '../kernelStatus';
+import type { NotebookPanel } from '@jupyterlab/notebook';
+
+const stream = (text: string): any => ({
+  output_type: 'stream',
+  name: 'stdout',
+  text
+});
+
+function createCell(outputs: any[]): {
+  cell: CodeCell;
+  add: jest.Mock;
+  clear: jest.Mock;
+  setOutputs: jest.Mock;
+} {
+  const add = jest.fn();
+  const clear = jest.fn();
+  const setOutputs = jest.fn();
+  return {
+    cell: {
+      model: {
+        sharedModel: {
+          getId: () => 'cell-id',
+          getOutputs: () => outputs,
+          setOutputs
+        }
+      },
+      outputArea: { model: { add, clear } }
+    } as unknown as CodeCell,
+    add,
+    clear,
+    setOutputs
+  };
+}
 
 describe('jupyter-server-nbmodel', () => {
-  it('should be tested', () => {
-    expect(1 + 1).toEqual(2);
+  it('restores status through the standard kernel connection', () => {
+    const updateStatus = jest.fn();
+    const panel = {
+      context: {
+        sessionContext: {
+          session: { kernel: { _updateStatus: updateStatus } }
+        }
+      }
+    } as unknown as NotebookPanel;
+
+    expect(restoreKernelStatus(panel, 'busy')).toBe(true);
+    expect(updateStatus).toHaveBeenCalledWith('busy');
+  });
+
+  it('restores the execution state from the existing kernel model', async () => {
+    const updateStatus = jest.fn();
+    const refreshRunning = jest.fn().mockResolvedValue(undefined);
+    const panel = {
+      context: {
+        sessionContext: {
+          kernelManager: {
+            refreshRunning,
+            running: () =>
+              [{ id: 'kernel-id', execution_state: 'busy' }][Symbol.iterator]()
+          },
+          session: {
+            kernel: {
+              id: 'kernel-id',
+              status: 'unknown',
+              _updateStatus: updateStatus
+            }
+          }
+        }
+      }
+    } as unknown as NotebookPanel;
+
+    expect(await restoreKernelModelStatus(panel)).toBe(true);
+    expect(refreshRunning).toHaveBeenCalledTimes(1);
+    expect(updateStatus).toHaveBeenCalledWith('busy');
+  });
+
+  it('persists the request identity needed after refresh', () => {
+    let metadata: unknown;
+    const cell = {
+      model: {
+        getMetadata: () => metadata,
+        setMetadata: (_key: string, value: unknown) => {
+          metadata = value;
+        },
+        deleteMetadata: () => {
+          metadata = undefined;
+        }
+      }
+    } as unknown as CodeCell;
+    const execution = {
+      kernelId: 'kernel-id',
+      requestId: 'request-id',
+      requestUrl: '/api/kernels/kernel-id/requests/request-id'
+    };
+
+    setServerExecutionMetadata(cell, execution);
+    expect(getServerExecutionMetadata(cell)).toEqual(execution);
+    clearServerExecutionMetadata(cell);
+    expect(getServerExecutionMetadata(cell)).toBeUndefined();
+  });
+
+  it('recognizes a shorter stream snapshot as a prefix', () => {
+    expect(isOutputPrefix([stream('1\n')], [stream('1\n2\n')])).toBe(true);
+    expect(isOutputPrefix([stream('1\n2\n')], [stream('1\n')])).toBe(false);
+  });
+
+  it('does not erase output for an initial empty snapshot', () => {
+    const { cell, clear, setOutputs } = createCell([stream('1\n')]);
+
+    reconcileOutputSnapshot(cell, []);
+
+    expect(clear).not.toHaveBeenCalled();
+    expect(setOutputs).not.toHaveBeenCalled();
+  });
+
+  it('does not replace output with an older stream snapshot', () => {
+    const { cell, add, setOutputs } = createCell([stream('1\n2\n')]);
+
+    reconcileOutputSnapshot(cell, [stream('1\n')], []);
+
+    expect(add).not.toHaveBeenCalled();
+    expect(setOutputs).not.toHaveBeenCalled();
+  });
+
+  it('appends only the missing stream suffix', () => {
+    const { cell, add, setOutputs } = createCell([stream('1\n')]);
+
+    reconcileOutputSnapshot(cell, [stream('1\n2\n')], [stream('1\n')]);
+
+    expect(add).toHaveBeenCalledTimes(1);
+    expect(add).toHaveBeenCalledWith(stream('2\n'));
+    expect(setOutputs).not.toHaveBeenCalled();
   });
 });

--- a/src/executionMetadata.ts
+++ b/src/executionMetadata.ts
@@ -18,7 +18,8 @@ export function getServerExecutionMetadata(
   cell: CodeCell
 ): IServerExecutionMetadata | undefined {
   const value = cell.model.getMetadata(EXECUTION_METADATA_KEY) as
-    Partial<IServerExecutionMetadata> | undefined;
+    | Partial<IServerExecutionMetadata>
+    | undefined;
   return value?.kernelId && value.requestId && value.requestUrl
     ? (value as IServerExecutionMetadata)
     : undefined;

--- a/src/executionMetadata.ts
+++ b/src/executionMetadata.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024-2025 Datalayer, Inc.
+ *
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import type { CodeCell } from '@jupyterlab/cells';
+
+export const EXECUTION_METADATA_KEY = 'jupyter_server_nbmodel';
+
+export interface IServerExecutionMetadata {
+  kernelId: string;
+  requestId: string;
+  requestUrl: string;
+}
+
+export function getServerExecutionMetadata(
+  cell: CodeCell
+): IServerExecutionMetadata | undefined {
+  const value = cell.model.getMetadata(EXECUTION_METADATA_KEY) as
+    Partial<IServerExecutionMetadata> | undefined;
+  return value?.kernelId && value.requestId && value.requestUrl
+    ? (value as IServerExecutionMetadata)
+    : undefined;
+}
+
+export function setServerExecutionMetadata(
+  cell: CodeCell,
+  metadata: IServerExecutionMetadata
+): void {
+  cell.model.setMetadata(EXECUTION_METADATA_KEY, metadata);
+}
+
+export function clearServerExecutionMetadata(cell: CodeCell): void {
+  cell.model.deleteMetadata(EXECUTION_METADATA_KEY);
+}

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -12,7 +12,9 @@ import { INotebookCellExecutor } from '@jupyterlab/notebook';
 import { ServerConnection } from '@jupyterlab/services';
 import { nullTranslator } from '@jupyterlab/translation';
 import { JSONExt } from '@lumino/coreutils';
-import { normalizeServerOutputs, requestServer } from './requestServer';
+import { clearServerExecutionMetadata } from './executionMetadata';
+import { normalizeServerOutputs } from './outputReconciliation';
+import { requestServer } from './requestServer';
 
 /**
  * Notebook cell executor posting a request to the server for execution.
@@ -151,6 +153,7 @@ export class NotebookCellServerExecutor implements INotebookCellExecutor {
             );
             const data = await response.json();
             success = data['status'] === 'ok';
+            clearServerExecutionMetadata(cell as CodeCell);
 
             const serverOutputs = normalizeServerOutputs(
               data['outputs'] ?? '[]'
@@ -219,6 +222,45 @@ export class NotebookCellServerExecutor implements INotebookCellExecutor {
         break;
     }
     return Promise.resolve(true);
+  }
+}
+
+/**
+ * Resume polling an execution request persisted in cell metadata.
+ */
+export async function resumeCellServerExecution(
+  cell: CodeCell,
+  requestUrl: string,
+  serverSettings: ServerConnection.ISettings
+): Promise<boolean> {
+  const sharedCodeCell = (cell.model as ICodeCellModel).sharedModel;
+  sharedCodeCell.executionState = 'running';
+  try {
+    const response = await requestServer(
+      cell,
+      requestUrl,
+      { method: 'GET' },
+      serverSettings
+    );
+    const data = await response.json();
+    const serverOutputs = normalizeServerOutputs(data['outputs'] ?? '[]');
+    if (!JSONExt.deepEqual(sharedCodeCell.getOutputs(), serverOutputs)) {
+      sharedCodeCell.setOutputs(serverOutputs);
+    }
+    sharedCodeCell.execution_count = data['execution_count'] ?? null;
+    sharedCodeCell.executionState = 'idle';
+    clearServerExecutionMetadata(cell);
+    return data['status'] === 'ok';
+  } catch (error) {
+    if (
+      error instanceof ServerConnection.ResponseError &&
+      error.response.status === 404
+    ) {
+      clearServerExecutionMetadata(cell);
+      sharedCodeCell.executionState = 'idle';
+      return false;
+    }
+    throw error;
   }
 }
 

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -11,7 +11,8 @@ import type { ICodeCellModel, MarkdownCell } from '@jupyterlab/cells';
 import { INotebookCellExecutor } from '@jupyterlab/notebook';
 import { ServerConnection } from '@jupyterlab/services';
 import { nullTranslator } from '@jupyterlab/translation';
-import { requestServer } from './requestServer';
+import { JSONExt } from '@lumino/coreutils';
+import { normalizeServerOutputs, requestServer } from './requestServer';
 
 /**
  * Notebook cell executor posting a request to the server for execution.
@@ -96,6 +97,7 @@ export class NotebookCellServerExecutor implements INotebookCellExecutor {
           const code = cell.model.sharedModel.getSource();
           const cellId = cell.model.sharedModel.getId();
           const documentId = notebook.sharedModel.getState('document_id');
+          const documentPath = sessionContext.session?.path;
           const { recordTiming } = notebookConfig;
           const kernelSettings = sessionContext.session?.kernel?.serverSettings;
           const remoteServer =
@@ -114,11 +116,29 @@ export class NotebookCellServerExecutor implements INotebookCellExecutor {
               metadata: {
                 cell_id: cellId,
                 document_id: documentId,
+                document_path: documentPath,
                 record_timing: recordTiming
               }
             })
           };
           onCellExecutionScheduled({ cell });
+          const sharedCodeCell = (cell.model as ICodeCellModel).sharedModel;
+          let sharedModelUpdates = 0;
+          const onSharedModelChanged = (): void => {
+            sharedModelUpdates += 1;
+            if (sharedModelUpdates <= 3) {
+              console.debug(
+                '[jupyter-server-nbmodel] Received shared cell update',
+                {
+                  cellId,
+                  documentId,
+                  documentPath,
+                  sharedModelUpdates
+                }
+              );
+            }
+          };
+          sharedCodeCell.changed.connect(onSharedModelChanged);
           let success = false;
           try {
             // FIXME quid of deletedCells and timing record.
@@ -131,6 +151,50 @@ export class NotebookCellServerExecutor implements INotebookCellExecutor {
             );
             const data = await response.json();
             success = data['status'] === 'ok';
+
+            const serverOutputs = normalizeServerOutputs(
+              data['outputs'] ?? '[]'
+            );
+            const sharedOutputs = sharedCodeCell.getOutputs();
+            const executionCount = data['execution_count'] ?? null;
+            const outputsMissing = !JSONExt.deepEqual(
+              sharedOutputs,
+              serverOutputs
+            );
+            const executionCountMissing =
+              sharedCodeCell.execution_count !== executionCount;
+
+            console.debug('[jupyter-server-nbmodel] Execution completed', {
+              cellId,
+              documentId,
+              documentPath,
+              sharedModelUpdates,
+              serverOutputCount: serverOutputs.length,
+              sharedOutputCount: sharedOutputs.length,
+              outputsMissing,
+              executionCountMissing
+            });
+
+            // Server-side collaboration is the streaming path. If its update
+            // was unavailable (no collaboration extension) or could not be
+            // integrated (for example an invalid historical YStore), reconcile
+            // the completed result returned by the REST endpoint in the client.
+            if (outputsMissing || executionCountMissing) {
+              console.warn(
+                '[jupyter-server-nbmodel] Reconciling missing server execution update',
+                {
+                  cellId,
+                  documentId,
+                  documentPath,
+                  sharedModelUpdates,
+                  outputsMissing,
+                  executionCountMissing
+                }
+              );
+              sharedCodeCell.setOutputs(serverOutputs);
+              sharedCodeCell.execution_count = executionCount;
+              sharedCodeCell.executionState = 'idle';
+            }
           } catch (error: unknown) {
             onCellExecuted({
               cell,
@@ -141,6 +205,8 @@ export class NotebookCellServerExecutor implements INotebookCellExecutor {
             } else {
               throw error;
             }
+          } finally {
+            sharedCodeCell.changed.disconnect(onSharedModelChanged);
           }
           onCellExecuted({ cell, success });
           return true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,6 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-import { notebookCellExecutor } from './plugin';
+import { notebookCellExecutor, notebookExecutionRestorer } from './plugin';
 
-export default notebookCellExecutor;
+export default [notebookCellExecutor, notebookExecutionRestorer];

--- a/src/kernelStatus.ts
+++ b/src/kernelStatus.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2024-2025 Datalayer, Inc.
+ *
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import type { NotebookPanel } from '@jupyterlab/notebook';
+import type { Kernel } from '@jupyterlab/services';
+
+const KERNEL_STATUSES = new Set<Kernel.Status>([
+  'unknown',
+  'starting',
+  'idle',
+  'busy',
+  'terminating',
+  'restarting',
+  'autorestarting',
+  'dead'
+]);
+
+/**
+ * Restore the status on JupyterLab's kernel connection.
+ *
+ * JupyterLab deliberately initializes a newly created kernel connection with
+ * an `unknown` status. The public kernel API has no status setter because the
+ * value normally comes from IOPub. A page refreshed during an execution has
+ * missed the earlier `busy` message, however, while the server request endpoint
+ * still knows the authoritative state. KernelConnection._updateStatus is the
+ * same internal path used for IOPub status messages and emits all standard
+ * statusChanged signals.
+ */
+export function restoreKernelStatus(
+  panel: NotebookPanel,
+  status: Kernel.Status
+): boolean {
+  const kernel = panel.context.sessionContext.session?.kernel as
+    | (Kernel.IKernelConnection & {
+        _updateStatus?: (value: Kernel.Status) => void;
+      })
+    | null
+    | undefined;
+  if (!kernel?._updateStatus) {
+    return false;
+  }
+  kernel._updateStatus(status);
+  return true;
+}
+
+/**
+ * Initialize a refreshed connection from Jupyter Server's existing kernel
+ * model, which contains the execution state that the new WebSocket missed.
+ */
+export async function restoreKernelModelStatus(
+  panel: NotebookPanel
+): Promise<boolean> {
+  const sessionContext = panel.context.sessionContext;
+  const kernel = sessionContext.session?.kernel;
+  const kernelManager = sessionContext.kernelManager;
+  if (!kernel || !kernelManager || kernel.status !== 'unknown') {
+    return false;
+  }
+
+  await kernelManager.refreshRunning();
+  const model = Array.from(kernelManager.running()).find(
+    candidate => candidate.id === kernel.id
+  );
+  const status = model?.execution_state;
+  return status && KERNEL_STATUSES.has(status as Kernel.Status)
+    ? restoreKernelStatus(panel, status as Kernel.Status)
+    : false;
+}

--- a/src/outputReconciliation.ts
+++ b/src/outputReconciliation.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2024-2025 Datalayer, Inc.
+ *
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import type { CodeCell, ICodeCellModel } from '@jupyterlab/cells';
+import { JSONExt } from '@lumino/coreutils';
+
+/**
+ * Parse server outputs and apply JupyterLab's consecutive stream merge rule.
+ */
+export function normalizeServerOutputs(outputs: string | unknown[]): any[] {
+  const rawOutputs = (
+    typeof outputs === 'string' ? JSON.parse(outputs) : outputs
+  ) as any[];
+  return rawOutputs.reduce<any[]>((merged, output) => {
+    const previous = merged[merged.length - 1];
+    if (
+      output.output_type === 'stream' &&
+      previous?.output_type === 'stream' &&
+      previous.name === output.name
+    ) {
+      const previousText = Array.isArray(previous.text)
+        ? previous.text.join('')
+        : (previous.text ?? '');
+      const text = Array.isArray(output.text)
+        ? output.text.join('')
+        : (output.text ?? '');
+      previous.text = previousText + text;
+    } else {
+      merged.push(output);
+    }
+    return merged;
+  }, []);
+}
+
+function streamText(output: any): string {
+  return Array.isArray(output.text)
+    ? output.text.join('')
+    : (output.text ?? '');
+}
+
+function isStreamPrefix(prefix: any, output: any): boolean {
+  return (
+    prefix?.output_type === 'stream' &&
+    output?.output_type === 'stream' &&
+    prefix.name === output.name &&
+    streamText(output).startsWith(streamText(prefix))
+  );
+}
+
+/**
+ * Whether every output in `prefix` is present at the beginning of `outputs`.
+ * The final stream may contain a text prefix rather than the complete text.
+ */
+export function isOutputPrefix(prefix: any[], outputs: any[]): boolean {
+  if (prefix.length > outputs.length) {
+    return false;
+  }
+  return prefix.every((output, index) => {
+    return (
+      JSONExt.deepEqual(output, outputs[index]) ||
+      (index === prefix.length - 1 && isStreamPrefix(output, outputs[index]))
+    );
+  });
+}
+
+/**
+ * Append the part of a server snapshot missing from the output-area model.
+ * Using the output-area API preserves the existing stream widget and lets the
+ * cell model translate the append into a Y.Text insertion.
+ */
+function appendOutputSuffix(
+  cell: CodeCell,
+  currentOutputs: any[],
+  serverOutputs: any[]
+): void {
+  let nextOutput = currentOutputs.length;
+  if (currentOutputs.length > 0) {
+    const lastIndex = currentOutputs.length - 1;
+    const current = currentOutputs[lastIndex];
+    const server = serverOutputs[lastIndex];
+    if (!JSONExt.deepEqual(current, server)) {
+      const text = streamText(server).slice(streamText(current).length);
+      if (text) {
+        cell.outputArea.model.add({ ...server, text });
+      }
+    }
+  }
+
+  while (nextOutput < serverOutputs.length) {
+    cell.outputArea.model.add(serverOutputs[nextOutput]);
+    nextOutput += 1;
+  }
+}
+
+/**
+ * Reconcile one pending output snapshot without allowing an older snapshot to
+ * replace newer collaborative output.
+ */
+export function reconcileOutputSnapshot(
+  cell: CodeCell,
+  serverOutputs: any[],
+  previousServerOutputs?: any[]
+): void {
+  const sharedCodeCell = (cell.model as ICodeCellModel).sharedModel;
+  const currentOutputs = sharedCodeCell.getOutputs();
+  if (JSONExt.deepEqual(currentOutputs, serverOutputs)) {
+    return;
+  }
+
+  // An initial empty snapshot can arrive after a collaborative output update.
+  // Never let that older snapshot erase output already visible in the cell.
+  // A transition from non-empty to empty, however, represents clear_output.
+  if (serverOutputs.length === 0) {
+    if (previousServerOutputs?.length && currentOutputs.length) {
+      cell.outputArea.model.clear();
+    }
+    return;
+  }
+
+  // The collaborative path may be ahead of this HTTP response. Applying the
+  // older snapshot would make output disappear and then reappear on the next
+  // poll, so leave the newer model untouched.
+  if (isOutputPrefix(serverOutputs, currentOutputs)) {
+    return;
+  }
+
+  console.debug('[jupyter-server-nbmodel] Applying pending output snapshot', {
+    cellId: sharedCodeCell.getId(),
+    outputCount: serverOutputs.length
+  });
+  if (isOutputPrefix(currentOutputs, serverOutputs)) {
+    appendOutputSuffix(cell, currentOutputs, serverOutputs);
+  } else {
+    // Non-monotonic output changes (for example update_display_data) cannot be
+    // represented as an append and still require authoritative replacement.
+    sharedCodeCell.setOutputs(serverOutputs);
+  }
+}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -8,8 +8,171 @@ import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
-import { INotebookCellExecutor } from '@jupyterlab/notebook';
-import { NotebookCellServerExecutor } from './executor';
+import { CodeCell } from '@jupyterlab/cells';
+import { URLExt } from '@jupyterlab/coreutils';
+import {
+  INotebookCellExecutor,
+  INotebookTracker,
+  NotebookPanel
+} from '@jupyterlab/notebook';
+import { ServerConnection } from '@jupyterlab/services';
+import {
+  getServerExecutionMetadata,
+  setServerExecutionMetadata
+} from './executionMetadata';
+import {
+  NotebookCellServerExecutor,
+  resumeCellServerExecution
+} from './executor';
+import { restoreKernelModelStatus, restoreKernelStatus } from './kernelStatus';
+
+const resumedRequests = new Set<string>();
+
+interface IActiveExecution {
+  cell_id?: string;
+  document_path?: string;
+  kernel_id: string;
+  request_id: string;
+  request_url: string;
+}
+
+async function resumeCellExecution(
+  cell: CodeCell,
+  panel: NotebookPanel,
+  app: JupyterFrontEnd
+): Promise<void> {
+  if (panel.isDisposed) {
+    return;
+  }
+
+  const execution = getServerExecutionMetadata(cell);
+  if (!execution || resumedRequests.has(execution.requestId)) {
+    return;
+  }
+
+  resumedRequests.add(execution.requestId);
+  const requestUrl = execution.requestUrl.startsWith(
+    app.serviceManager.serverSettings.baseUrl
+  )
+    ? execution.requestUrl
+    : URLExt.join(
+        app.serviceManager.serverSettings.baseUrl,
+        execution.requestUrl
+      );
+  restoreKernelStatus(panel, 'busy');
+  void resumeCellServerExecution(
+    cell,
+    requestUrl,
+    app.serviceManager.serverSettings
+  )
+    .then(() => {
+      restoreKernelStatus(panel, 'idle');
+    })
+    .catch(error => {
+      restoreKernelStatus(panel, 'unknown');
+      console.error(
+        `Failed to resume server execution ${execution.requestId}.`,
+        error
+      );
+    })
+    .finally(() => {
+      resumedRequests.delete(execution.requestId);
+    });
+}
+
+async function watchNotebookExecutions(
+  panel: NotebookPanel,
+  app: JupyterFrontEnd
+): Promise<void> {
+  await Promise.all([panel.context.ready, panel.context.sessionContext.ready]);
+  if (panel.isDisposed) {
+    return;
+  }
+
+  try {
+    await restoreKernelModelStatus(panel);
+  } catch (error) {
+    console.warn(
+      '[jupyter-server-nbmodel] Failed to restore the kernel model status.',
+      error
+    );
+  }
+
+  const watchedCells = new WeakSet<CodeCell>();
+  const watchCells = (): void => {
+    for (const widget of panel.content.widgets) {
+      if (!(widget instanceof CodeCell) || watchedCells.has(widget)) {
+        continue;
+      }
+      watchedCells.add(widget);
+      widget.model.metadataChanged.connect((_sender, change) => {
+        if (change.key === 'jupyter_server_nbmodel') {
+          void resumeCellExecution(widget, panel, app);
+        }
+      });
+      void resumeCellExecution(widget, panel, app);
+    }
+  };
+
+  // YStore/collaboration updates may restore the active request metadata just
+  // after the document context becomes ready. Keep watching instead of making
+  // restoration depend on that one timing window.
+  panel.content.modelContentChanged.connect(watchCells);
+  panel.disposed.connect(() => {
+    panel.content.modelContentChanged.disconnect(watchCells);
+  });
+  watchCells();
+
+  const kernelId = panel.context.sessionContext.session?.kernel?.id;
+  if (!kernelId) {
+    return;
+  }
+  const executeUrl = URLExt.join(
+    app.serviceManager.serverSettings.baseUrl,
+    `api/kernels/${kernelId}/execute`
+  );
+  try {
+    const response = await ServerConnection.makeRequest(
+      executeUrl,
+      { method: 'GET' },
+      app.serviceManager.serverSettings
+    );
+    if (!response.ok) {
+      throw await ServerConnection.ResponseError.create(response);
+    }
+    const payload = (await response.json()) as {
+      requests?: IActiveExecution[];
+    };
+    const documentPath = panel.context.sessionContext.session?.path;
+    for (const execution of payload.requests ?? []) {
+      if (
+        !execution.cell_id ||
+        (execution.document_path && execution.document_path !== documentPath)
+      ) {
+        continue;
+      }
+      const cell = panel.content.widgets.find(
+        widget =>
+          widget instanceof CodeCell &&
+          widget.model.sharedModel.getId() === execution.cell_id
+      );
+      if (!(cell instanceof CodeCell)) {
+        continue;
+      }
+      setServerExecutionMetadata(cell, {
+        kernelId: execution.kernel_id,
+        requestId: execution.request_id,
+        requestUrl: execution.request_url
+      });
+      void resumeCellExecution(cell, panel, app);
+    }
+  } catch (error) {
+    console.warn(
+      '[jupyter-server-nbmodel] Failed to discover active executions.',
+      error
+    );
+  }
+}
 
 export const notebookCellExecutor: JupyterFrontEndPlugin<INotebookCellExecutor> =
   {
@@ -26,3 +189,18 @@ export const notebookCellExecutor: JupyterFrontEndPlugin<INotebookCellExecutor> 
       return executor;
     }
   };
+
+export const notebookExecutionRestorer: JupyterFrontEndPlugin<void> = {
+  id: '@datalayer/jupyter-server-nbmodel:notebook-execution-restorer',
+  description: 'Resumes server-side notebook executions after a page refresh.',
+  autoStart: true,
+  requires: [INotebookTracker],
+  activate: (app: JupyterFrontEnd, tracker: INotebookTracker): void => {
+    tracker.widgetAdded.connect((_sender, panel) => {
+      void watchNotebookExecutions(panel, app);
+    });
+    tracker.forEach(panel => {
+      void watchNotebookExecutions(panel, app);
+    });
+  }
+};

--- a/src/requestServer.ts
+++ b/src/requestServer.ts
@@ -4,86 +4,75 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-import { CodeCell } from '@jupyterlab/cells';
-import type { ICodeCellModel } from '@jupyterlab/cells';
+import type { CodeCell } from '@jupyterlab/cells';
 import { URLExt } from '@jupyterlab/coreutils';
 import { OutputPrompt, Stdin } from '@jupyterlab/outputarea';
 import { Kernel, ServerConnection } from '@jupyterlab/services';
 import { IHeader, IInputReply } from '@jupyterlab/services/lib/kernel/messages';
 import type { ITranslator } from '@jupyterlab/translation';
-import { JSONExt, PromiseDelegate } from '@lumino/coreutils';
+import { PromiseDelegate } from '@lumino/coreutils';
 import { Panel } from '@lumino/widgets';
+import { setServerExecutionMetadata } from './executionMetadata';
+import {
+  normalizeServerOutputs,
+  reconcileOutputSnapshot
+} from './outputReconciliation';
 
 /**
  * Polling interval for accepted execution requests.
  */
 const MAX_POLLING_INTERVAL = 1000;
 
-/**
- * Parse server outputs and apply JupyterLab's consecutive stream merge rule.
- */
-export function normalizeServerOutputs(outputs: string | unknown[]): any[] {
-  const rawOutputs = (
-    typeof outputs === 'string' ? JSON.parse(outputs) : outputs
-  ) as any[];
-  return rawOutputs.reduce<any[]>((merged, output) => {
-    const previous = merged[merged.length - 1];
-    if (
-      output.output_type === 'stream' &&
-      previous?.output_type === 'stream' &&
-      previous.name === output.name
-    ) {
-      const previousText = Array.isArray(previous.text)
-        ? previous.text.join('')
-        : (previous.text ?? '');
-      const text = Array.isArray(output.text)
-        ? output.text.join('')
-        : (output.text ?? '');
-      previous.text = previousText + text;
-    } else {
-      merged.push(output);
-    }
-    return merged;
-  }, []);
+interface IOutputReconciliationState {
+  serverOutputs?: any[];
 }
 
-/**
- * Apply an in-progress output snapshot when collaborative updates did not
- * reach this browser. Healthy shared documents already contain the same
- * outputs, so polling remains a no-op for their normal streaming path.
- */
+interface IRequestProgressPayload {
+  kernel_id?: string;
+  outputs?: string | unknown[];
+  request_id?: string;
+  request_url?: string;
+}
+
 async function reconcilePendingOutputs(
   cell: CodeCell,
-  response: Response
+  response: Response,
+  state: IOutputReconciliationState
 ): Promise<void> {
-  let payload: { outputs?: string | unknown[] };
+  let payload: IRequestProgressPayload;
   try {
     payload = await response.json();
   } catch {
     return;
   }
+  if (payload.request_id && payload.kernel_id) {
+    const requestUrl = response.headers.get('Location') ?? payload.request_url;
+    if (requestUrl) {
+      setServerExecutionMetadata(cell, {
+        kernelId: payload.kernel_id,
+        requestId: payload.request_id,
+        requestUrl
+      });
+    }
+  }
+
   if (payload.outputs === undefined) {
     return;
   }
-
   const serverOutputs = normalizeServerOutputs(payload.outputs);
-  const sharedCodeCell = (cell.model as ICodeCellModel).sharedModel;
-  if (!JSONExt.deepEqual(sharedCodeCell.getOutputs(), serverOutputs)) {
-    console.debug('[jupyter-server-nbmodel] Applying pending output snapshot', {
-      cellId: sharedCodeCell.getId(),
-      outputCount: serverOutputs.length
-    });
-    sharedCodeCell.setOutputs(serverOutputs);
-  }
+  const previousServerOutputs = state.serverOutputs;
+  state.serverOutputs = serverOutputs;
+  reconcileOutputSnapshot(cell, serverOutputs, previousServerOutputs);
 }
 
-export async function requestServer(
+async function requestServerWithState(
   cell: CodeCell,
   url: string,
   init: RequestInit,
   settings: ServerConnection.ISettings,
   translator?: ITranslator,
-  interval = 100
+  interval = 100,
+  reconciliationState: IOutputReconciliationState = {}
 ): Promise<Response> {
   const promise = new PromiseDelegate<Response>();
   ServerConnection.makeRequest(url, init, settings)
@@ -161,12 +150,14 @@ export async function requestServer(
                 focusedElement.focus();
               }
               try {
-                const response = await requestServer(
+                const response = await requestServerWithState(
                   cell,
                   url,
                   init,
                   settings,
-                  translator
+                  translator,
+                  100,
+                  reconciliationState
                 );
                 promise.resolve(response);
               } catch (error) {
@@ -179,7 +170,7 @@ export async function requestServer(
           promise.reject(await ServerConnection.ResponseError.create(response));
         }
       } else if (response.status === 202) {
-        await reconcilePendingOutputs(cell, response);
+        await reconcilePendingOutputs(cell, response, reconciliationState);
         let redirectUrl = response.headers.get('Location') || url;
         if (!redirectUrl.startsWith(settings.baseUrl)) {
           redirectUrl = URLExt.join(settings.baseUrl, redirectUrl);
@@ -191,16 +182,18 @@ export async function requestServer(
             init: RequestInit,
             settings: ServerConnection.ISettings,
             translator?: ITranslator,
-            interval?: number
+            interval?: number,
+            reconciliationState?: IOutputReconciliationState
           ) => {
             try {
-              const response = await requestServer(
+              const response = await requestServerWithState(
                 cell,
                 url,
                 init,
                 settings,
                 translator,
-                interval
+                interval,
+                reconciliationState
               );
               promise.resolve(response);
             } catch (error) {
@@ -214,7 +207,8 @@ export async function requestServer(
           settings,
           translator,
           // Evanescent interval
-          Math.min(MAX_POLLING_INTERVAL, interval * 2)
+          Math.min(MAX_POLLING_INTERVAL, interval * 2),
+          reconciliationState
         );
       } else {
         promise.resolve(response);
@@ -224,6 +218,25 @@ export async function requestServer(
       promise.reject(new ServerConnection.NetworkError(reason));
     });
   return promise.promise;
+}
+
+export async function requestServer(
+  cell: CodeCell,
+  url: string,
+  init: RequestInit,
+  settings: ServerConnection.ISettings,
+  translator?: ITranslator,
+  interval = 100
+): Promise<Response> {
+  return requestServerWithState(
+    cell,
+    url,
+    init,
+    settings,
+    translator,
+    interval,
+    {}
+  );
 }
 
 export default requestServer;

--- a/src/requestServer.ts
+++ b/src/requestServer.ts
@@ -5,18 +5,77 @@
  */
 
 import { CodeCell } from '@jupyterlab/cells';
+import type { ICodeCellModel } from '@jupyterlab/cells';
 import { URLExt } from '@jupyterlab/coreutils';
 import { OutputPrompt, Stdin } from '@jupyterlab/outputarea';
 import { Kernel, ServerConnection } from '@jupyterlab/services';
 import { IHeader, IInputReply } from '@jupyterlab/services/lib/kernel/messages';
 import type { ITranslator } from '@jupyterlab/translation';
-import { PromiseDelegate } from '@lumino/coreutils';
+import { JSONExt, PromiseDelegate } from '@lumino/coreutils';
 import { Panel } from '@lumino/widgets';
 
 /**
  * Polling interval for accepted execution requests.
  */
 const MAX_POLLING_INTERVAL = 1000;
+
+/**
+ * Parse server outputs and apply JupyterLab's consecutive stream merge rule.
+ */
+export function normalizeServerOutputs(outputs: string | unknown[]): any[] {
+  const rawOutputs = (
+    typeof outputs === 'string' ? JSON.parse(outputs) : outputs
+  ) as any[];
+  return rawOutputs.reduce<any[]>((merged, output) => {
+    const previous = merged[merged.length - 1];
+    if (
+      output.output_type === 'stream' &&
+      previous?.output_type === 'stream' &&
+      previous.name === output.name
+    ) {
+      const previousText = Array.isArray(previous.text)
+        ? previous.text.join('')
+        : (previous.text ?? '');
+      const text = Array.isArray(output.text)
+        ? output.text.join('')
+        : (output.text ?? '');
+      previous.text = previousText + text;
+    } else {
+      merged.push(output);
+    }
+    return merged;
+  }, []);
+}
+
+/**
+ * Apply an in-progress output snapshot when collaborative updates did not
+ * reach this browser. Healthy shared documents already contain the same
+ * outputs, so polling remains a no-op for their normal streaming path.
+ */
+async function reconcilePendingOutputs(
+  cell: CodeCell,
+  response: Response
+): Promise<void> {
+  let payload: { outputs?: string | unknown[] };
+  try {
+    payload = await response.json();
+  } catch {
+    return;
+  }
+  if (payload.outputs === undefined) {
+    return;
+  }
+
+  const serverOutputs = normalizeServerOutputs(payload.outputs);
+  const sharedCodeCell = (cell.model as ICodeCellModel).sharedModel;
+  if (!JSONExt.deepEqual(sharedCodeCell.getOutputs(), serverOutputs)) {
+    console.debug('[jupyter-server-nbmodel] Applying pending output snapshot', {
+      cellId: sharedCodeCell.getId(),
+      outputCount: serverOutputs.length
+    });
+    sharedCodeCell.setOutputs(serverOutputs);
+  }
+}
 
 export async function requestServer(
   cell: CodeCell,
@@ -120,6 +179,7 @@ export async function requestServer(
           promise.reject(await ServerConnection.ResponseError.create(response));
         }
       } else if (response.status === 202) {
+        await reconcilePendingOutputs(cell, response);
         let redirectUrl = response.headers.get('Location') || url;
         if (!redirectUrl.startsWith(settings.baseUrl)) {
           redirectUrl = URLExt.join(settings.baseUrl, redirectUrl);


### PR DESCRIPTION
On the same server and kernel, a newly created notebook could stream
normally while an existing notebook executed without displaying anything. A
server restart alone did not consistently cause or resolve the problem, so the
important difference was the notebook's persisted collaborative history rather
than the lifetime of the kernel or server process.

There were ultimately three related but distinct failures:

1. Some historical YStore documents contained an unresolved CRDT dependency
   chain. The browser retained later updates in `Y.Doc.store.pendingStructs`,
   so the server could save the output while the browser never observed it.
   The operation that originally created every affected historical chain has
   not been isolated.
2. The HTTP recovery made the browser and server concurrent writers to the
   cell's shared output array. If the browser inserted the accumulated stream
   `1234` and the server then blindly appended its view of the same stream, the
   persisted result could become `12341234`. The server now compares the
   current shared text with its kernel-side accumulator and treats an already
   applied snapshot as a no-op.
3. An attempted fix used an array-wide authoritative synchronizer that deleted
   and replaced integrated output entries. A nested `Map`/`Text` replacement
   could temporarily expose `{output_type: "stream"}` without `text` to the
   JavaScript model. JupyterLab then failed in `OutputAreaModel._add` while
   calling `value.text.join("")`; code-cell construction aborted and the
   notebook appeared completely empty. That synchronizer was removed. The
   current hook never replaces or deletes integrated output-array entries.

This PR also fixes https://github.com/datalayer/jupyter-server-nbmodel/issues/63